### PR TITLE
Changes required to build for ia32-qemu

### DIFF
--- a/build-core-arm-imx6ull.sh
+++ b/build-core-arm-imx6ull.sh
@@ -10,9 +10,9 @@
 
 b_log "Building phoenix-rtos-kernel"
 
-KERNEL_MAKECMDGOALS=""
+KERNEL_MAKECMDGOALS="install-headers"
 if [ "X$CLEAN" == "Xclean" ]; then
-	KERNEL_MAKECMDGOALS="$CLEAN install-headers"
+    KERNEL_MAKECMDGOALS="$CLEAN $KERNEL_MAKECMDGOALS"
 fi
 
 (cd phoenix-rtos-kernel/src/ && make $MAKEFLAGS $KERNEL_MAKECMDGOALS all)

--- a/build-core-armv7-stm32.sh
+++ b/build-core-armv7-stm32.sh
@@ -10,9 +10,9 @@
 
 b_log "Building phoenix-rtos-kernel"
 
-KERNEL_MAKECMDGOALS=""
+KERNEL_MAKECMDGOALS="install-headers"
 if [ "X$CLEAN" == "Xclean" ]; then
-	KERNEL_MAKECMDGOALS="$CLEAN install-headers"
+    KERNEL_MAKECMDGOALS="$CLEAN $KERNEL_MAKECMDGOALS"
 fi
 
 (cd phoenix-rtos-kernel/src/ && make $MAKEFLAGS $KERNEL_MAKECMDGOALS all)

--- a/build-core-ia32-qemu.sh
+++ b/build-core-ia32-qemu.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Shell script for building Phoenix-RTOS firmware
+#
+# Builder for Phoenix-RTOS core components
+#
+# Copyright 2019 Phoenix Systems
+# Author: Kaja Swat, Aleksander Kaminski, Pawel Pisarczyk, Lukasz Kosinski
+#
+
+b_log "Building phoenix-rtos-kernel"
+
+KERNEL_MAKECMDGOALS="install-headers"
+if [ "X$CLEAN" == "Xclean" ]; then
+    KERNEL_MAKECMDGOALS="$CLEAN $KERNEL_MAKECMDGOALS"
+fi
+
+(cd phoenix-rtos-kernel/src && make $MAKEFLAGS $KERNEL_MAKECMDGOALS all)
+cp -a phoenix-rtos-kernel/phoenix-ia32-qemu.elf _build
+cp -a phoenix-rtos-kernel/phoenix-ia32-qemu.img _build
+
+b_log "Building libphoenix"
+(cd libphoenix && make $MAKEFLAGS $CLEAN all install)
+
+b_log "Building phoenix-rtos-filesystems"
+(cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)
+b_install "$PREFIX_PROG_STRIPPED/dummyfs" /sbin
+b_install "$PREFIX_PROG_STRIPPED/ext2" /sbin
+
+b_log "Building phoenix-rtos-devices"
+(cd phoenix-rtos-devices && make $MAKEFLAGS $CLEAN all)
+b_install "$PREFIX_PROG_STRIPPED/pc-tty" /sbin
+b_install "$PREFIX_PROG_STRIPPED/pc-uart" /sbin
+b_install "$PREFIX_PROG_STRIPPED/pc-ata" /sbin
+
+b_log "Building psh"
+(cd psh && make $MAKEFLAGS $CLEAN all)
+b_install "$PREFIX_PROG_STRIPPED/psh" /bin

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,6 @@ PREFIX_H="$PREFIX_BUILD/include/"
 
 PREFIX_ROOTFS="$PREFIX_FS/root/"
 
-CROSS=arm-phoenix-
 CFLAGS="${CFLAGS} -I${PREFIX_H}"
 LDFLAGS="$LDFLAGS -L$PREFIX_A"
 CC=${CROSS}gcc
@@ -115,11 +114,7 @@ mkdir -p $PREFIX_BUILD_HOST
 # Build core part
 #
 if [ "X${B_CORE}" == "Xy" ]; then
-	if [ "${TARGET_SUBFAMILY}" == "arm-imx6ull" ]; then
-		./phoenix-rtos-build/build-core-imx6ull.sh
-	elif [ "${TARGET_SUBFAMILY}" == "armv7-stm32" ]; then
-		./phoenix-rtos-build/build-core-stm32.sh
-	fi
+	./phoenix-rtos-build/build-core-${TARGET_SUBFAMILY}.sh
 fi
 
 #


### PR DESCRIPTION
Added changes necessary to build for ia32-qemu.
Build-core scripts for other architectures have been renamed for consistency.
The CROSS variable from build.sh has been removed. It should be defined separately for each project inside a build.project file. 