### PR TITLE
imxrt: Make sure _boot exists before copying psu/phoenixd

### DIFF
--- a/build-core-armv7-imxrt.sh
+++ b/build-core-armv7-imxrt.sh
@@ -31,5 +31,6 @@ b_log "Building coreutils"
 
 b_log "Building hostutils"
 (cd phoenix-rtos-hostutils/ && make $MAKEFLAGS $CLEAN all)
+mkdir -p "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/phoenixd" $PREFIX_BOOT
 cp "$PREFIX_BUILD_HOST/prog.stripped/psu" $PREFIX_BOOT


### PR DESCRIPTION
Right now if _boot directory doesn't exist, binary called _boot is
created.
Another solution would be to do that in build.sh, but I'm not sure if we always want to have it