### PR TITLE
Added 'set -e' to check for errors

### DIFF
--- a/build-core-ia32-qemu.sh
+++ b/build-core-ia32-qemu.sh
@@ -8,6 +8,8 @@
 # Author: Kaja Swat, Aleksander Kaminski, Pawel Pisarczyk, Lukasz Kosinski
 #
 
+set -e
+
 b_log "Building phoenix-rtos-kernel"
 KERNEL_MAKECMDGOALS="install-headers"
 (cd phoenix-rtos-kernel/src && make $MAKEFLAGS $CLEAN $KERNEL_MAKECMDGOALS all)


### PR DESCRIPTION
There was no error checking in the build core
The same should probably be added to other ```build-core-*``` files.