### PR TITLE
Stm32 tweaks

### DIFF
--- a/build-core-armv7-stm32.sh
+++ b/build-core-armv7-stm32.sh
@@ -19,8 +19,6 @@ b_log "Building libphoenix"
 
 b_log "Building phoenix-rtos-filesystems"
 (cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)
-b_install "$PREFIX_PROG_STRIPPED/meterfs" _build
 
 b_log "Building phoenix-rtos-devices"
 (cd phoenix-rtos-devices && make $MAKEFLAGS $CLEAN all)
-b_install "$PREFIX_PROG_STRIPPED/stm32-multi" _build


### PR DESCRIPTION
This pull request allow to compile targets without full phoenix environment with „all” command. Now it's not needed to have phoenix-rtos-ports or root-skel in project. Also I remove need of any project specific commands.
Added b_prepare hook, that will be executed before any other actions will be performed. It would be beneficial if any project specific action will need to be performed before any other action will be performed.
Also it adds some tweaks to receive git version on repositories saved into /etc/git-version
Also removed unneeded install command on stm32 core. 

I verified if this not breaks project builds.
@kaman confirmed that this not breaks build on MacOS systems. 