### PR TITLE
stm32: Build filesystems after devices

### DIFF
--- a/build-core-armv7-stm32.sh
+++ b/build-core-armv7-stm32.sh
@@ -17,8 +17,8 @@ cp -a phoenix-rtos-kernel/phoenix-$TARGET.img _build
 b_log "Building libphoenix"
 (cd libphoenix && make $MAKEFLAGS $CLEAN all install)
 
-b_log "Building phoenix-rtos-filesystems"
-(cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)
-
 b_log "Building phoenix-rtos-devices"
 (cd phoenix-rtos-devices && make $MAKEFLAGS $CLEAN all)
+
+b_log "Building phoenix-rtos-filesystems"
+(cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)


### PR DESCRIPTION
Now filesystems depend on devices (stm32-multi.h header), so devices need to be build first.