### PR TITLE
Revert "Makefile.armv7: removed repeated -g flag"

### DIFF
--- a/Makefile.armv7
+++ b/Makefile.armv7
@@ -14,7 +14,7 @@ MKDEPFLAGS = $(CFLAGS)
 CC = $(CROSS)gcc
 
 ifeq ($(DEBUG), 1)
-	CFLAGS += -Og
+	CFLAGS += -Og -g
 else
 	CFLAGS += -O2 -DNDEBUG
 endif


### PR DESCRIPTION
Sorry, merged too soon: https://stackoverflow.com/questions/12970596/gcc-4-8-does-og-imply-g