### PR TITLE
build-core-ia32-generic.sh: removed install ext2

### DIFF
--- a/build-core-ia32-generic.sh
+++ b/build-core-ia32-generic.sh
@@ -23,7 +23,7 @@ b_log "Building libphoenix"
 b_log "Building phoenix-rtos-filesystems"
 (cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)
 b_install "$PREFIX_PROG_STRIPPED/dummyfs" /sbin
-b_install "$PREFIX_PROG_STRIPPED/ext2" /sbin
+#b_install "$PREFIX_PROG_STRIPPED/ext2" /sbin
 
 b_log "Building phoenix-rtos-devices"
 (cd phoenix-rtos-devices && make $MAKEFLAGS $CLEAN all)


### PR DESCRIPTION
Now there is bug:
```
TARGET=ia32-generic

Installing dummyfs into /sbin 
/tmp/phoenix-rtos-project/_build/ia32-generic/prog.stripped//ext2 binary does not exist 
```
