### PR TITLE
armv7: fix no _boot directory

### DIFF
--- a/build-core-armv7m7-imxrt106x.sh
+++ b/build-core-armv7m7-imxrt106x.sh
@@ -44,6 +44,7 @@ b_install $PREFIX_PROG_STRIPPED/psd /sbin
 
 b_log "Building hostutils"
 (cd phoenix-rtos-hostutils/ && make $MAKEFLAGS $CLEAN all)
+mkdir -p "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/phoenixd" "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/psu" "$PREFIX_BOOT"
 


### PR DESCRIPTION
The build fails because _boot binary is created when copying phoenixd before _boot directory creation.