### PR TITLE
Remove passing include dir to kernel

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -91,7 +91,9 @@ PREFIX_PROG_STRIPPED ?= $(PREFIX_BUILD)/prog.stripped/
 
 # add include path for auto-generated files
 #CFLAGS += -I"$(BUILD_DIR)/$(CURR_SUFFIX)"
-CFLAGS += -I$(PREFIX_H)
+ifneq ($(KERNEL), 1)
+	CFLAGS += -I$(PREFIX_H)
+endif
 
 ARCH =  $(SIL)@mkdir -p $(@D); \
 	(printf "AR  %-24s\n" "$(@F)"); \

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,7 @@ PREFIX_H="$PREFIX_BUILD/include/"
 PREFIX_ROOTFS="$PREFIX_FS/root/"
 PREFIX_ROOTSKEL="$(pwd)/_fs//root-skel/"
 
-CFLAGS="${CFLAGS} -I${PREFIX_H} -Dphoenix"
+CFLAGS="${CFLAGS} -Dphoenix"
 LDFLAGS="$LDFLAGS -L$PREFIX_A"
 CC=${CROSS}gcc
 AS=${CROSS}as


### PR DESCRIPTION
Common include dir should not be passed to kernel. It hides issue from https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/121

Also removed passing include from build.sh – it duplicates parameter from Makefile 