### PR TITLE
toolchain: add proper riscv toolchain

### DIFF
--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -11,7 +11,7 @@ log() {
 
 if [ -z "$1" ]; then
     echo "No toolchain target provided! Abort."
-    echo "officially supported targets: arm-phoenix i386-pc-phoenix riscv64-phoenix-elf"
+    echo "officially supported targets: arm-phoenix i386-pc-phoenix riscv64-phoenix"
     exit 1
 fi
 

--- a/toolchain/gcc-9.3.0-02-i386-pc-phoenix.patch
+++ b/toolchain/gcc-9.3.0-02-i386-pc-phoenix.patch
@@ -12,7 +12,7 @@ diff -Naur gcc-9.3.0-orig/fixincludes/mkfixinc.sh gcc-9.3.0/fixincludes/mkfixinc
 diff -Naur gcc-9.3.0-orig/gcc/config.gcc gcc-9.3.0/gcc/config.gcc
 --- gcc-9.3.0-orig/gcc/config.gcc	2020-03-12 12:07:21.000000000 +0100
 +++ gcc-9.3.0/gcc/config.gcc	2020-03-18 19:25:57.937836171 +0100
-@@ -1635,6 +1637,9 @@
+@@ -1637,6 +1639,9 @@
  i[34567]86-*-elf*)
  	tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h newlib-stdint.h i386/i386elf.h"
  	;;

--- a/toolchain/gcc-9.3.0-03-riscv64-phoenix.patch
+++ b/toolchain/gcc-9.3.0-03-riscv64-phoenix.patch
@@ -1,0 +1,46 @@
+diff -Naur --exclude '*build*' --exclude '*gmp*' --exclude '*mpfr*' --exclude '*isl*' --exclude '*mpc*' gcc-9.3.0-orig/gcc/config/riscv/phoenix.h gcc-9.3.0/gcc/config/riscv/phoenix.h
+--- gcc-9.3.0-orig/gcc/config/riscv/phoenix.h	1970-01-01 01:00:00.000000000 +0100
++++ gcc-9.3.0/gcc/config/riscv/phoenix.h	2020-10-19 13:41:30.150476780 +0200
+@@ -0,0 +1,21 @@
++/* Target macros for riscv*-elf targets.
++   Copyright (C) 1994-2019 Free Software Foundation, Inc.
++
++This file is part of GCC.
++
++GCC is free software; you can redistribute it and/or modify
++it under the terms of the GNU General Public License as published by
++the Free Software Foundation; either version 3, or (at your option)
++any later version.
++
++GCC is distributed in the hope that it will be useful,
++but WITHOUT ANY WARRANTY; without even the implied warranty of
++MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++GNU General Public License for more details.
++
++You should have received a copy of the GNU General Public License
++along with GCC; see the file COPYING3.  If not see
++<http://www.gnu.org/licenses/>.  */
++
++/* Phoenix-RTOS does not provide libgloss, link remove if from default libs - see riscv/elf.h */
++#undef  LIB_SPEC
+diff -Naur --exclude '*build*' --exclude '*gmp*' --exclude '*mpfr*' --exclude '*isl*' --exclude '*mpc*' gcc-9.3.0-orig/gcc/config.gcc gcc-9.3.0/gcc/config.gcc
+--- gcc-9.3.0-orig/gcc/config.gcc	2020-10-19 13:24:43.512413024 +0200
++++ gcc-9.3.0/gcc/config.gcc	2020-10-19 13:41:49.274895804 +0200
+@@ -2218,13 +2218,16 @@
+ 	# automatically detect that GAS supports it, yet we require it.
+ 	gcc_cv_initfini_array=yes
+ 	;;
+-riscv*-*-elf* | riscv*-*-rtems*)
++riscv*-*-elf* | riscv*-*-rtems* | riscv*-*-phoenix*)
+ 	tm_file="elfos.h newlib-stdint.h ${tm_file} riscv/elf.h"
+ 	case ${target} in
+ 	*-*-rtems*)
+ 	  tm_file="${tm_file} rtems.h riscv/rtems.h"
+ 	  tmake_file="${tmake_file} riscv/t-rtems"
+ 	  ;;
++	*-*-phoenix*)
++	  tm_file="${tm_file} phoenix.h riscv/phoenix.h"
++	  ;;
+ 	*)
+ 	  case "x${enable_multilib}" in
+ 	  xno) ;;


### PR DESCRIPTION
Adding `riscv*-*-phoenix` target to gcc:
 - ensured `phoenix` is a STD define (provided by toolchain, no need to add `-Dphoenix` for riscv targets anymore)
 - removed `libgloss` link dependency

WARN: **this changes the riscv toolchain name to riscv64-phoenix-gcc**