### PR TITLE
Build enhancements

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -80,6 +80,17 @@ for i in "$@"; do
 done
 
 #
+# Clean if requested
+#
+if [ -n "$CLEAN" ]; then
+	b_log "Cleaning build dir"
+    rm -rf "$PREFIX_BUILD" "$PREFIX_BUILD_HOST"
+    rm -rf "$PREFIX_FS"
+    #FIXME: this should also remove unpacked sources in 'ports' (the easiest option is to move them to _boot)
+    #TODO: remove per-component CLEAN var dependency
+fi
+
+#
 # Prepare
 #
 mkdir -p "$PREFIX_BUILD"
@@ -95,9 +106,6 @@ git submodule status --recursive >> "${PREFIX_BUILD}/git-version"
 #
 if [ "${B_FS}" = "y" ] && [ -d  "${PREFIX_ROOTSKEL}" ]; then
 	b_log "Preparing filesystem"
-	if [ "$CLEAN" = "clean" ]; then
-		rm -fr "$PREFIX_FS/root/"*
-	fi
 
 	mkdir -p "${PREFIX_ROOTFS}"
 	cp -a "${PREFIX_ROOTSKEL}/." "${PREFIX_ROOTFS}"

--- a/build.sh
+++ b/build.sh
@@ -29,7 +29,6 @@ PREFIX_H="$PREFIX_BUILD/include/"
 PREFIX_ROOTFS="$PREFIX_FS/root/"
 PREFIX_ROOTSKEL="$(pwd)/_fs//root-skel/"
 
-CFLAGS="${CFLAGS} -Dphoenix"
 LDFLAGS="$LDFLAGS -L$PREFIX_A"
 CC=${CROSS}gcc
 AS=${CROSS}as


### PR DESCRIPTION
* remove `-Dphoenix` from `CFLAGS` - this define is no longer needed after introducing proper RISC-V
toolchain
**after this change new toolchain for `riscv64` targets will need to be used**
* better 'clean' command support

This is only partial work, all created/changed files should lie either in
`_build/$TARGET` or `_fs/$TARGET`, so cleaning should be as simple as
removing these directories.

Most of the remaining work needs to be done in `phoenix-rtos-ports` and
in `plo`.

**please use REBASE MERGE STRATEGY when merging this pull request**