### PR TITLE
imxrt: fix build break when no clean option provided

### DIFF
--- a/build-core-armv7m7-imxrt106x.sh
+++ b/build-core-armv7m7-imxrt106x.sh
@@ -13,40 +13,40 @@ set -e
 
 b_log "Building phoenix-rtos-kernel"
 KERNEL_MAKECMDGOALS="install-headers"
-(cd phoenix-rtos-kernel && make $MAKEFLAGS "$CLEAN" $KERNEL_MAKECMDGOALS all)
+(cd phoenix-rtos-kernel && make $MAKEFLAGS $CLEAN $KERNEL_MAKECMDGOALS all)
 
 b_log "Building libphoenix"
-(cd libphoenix && make $MAKEFLAGS "$CLEAN" all install)
+(cd libphoenix && make $MAKEFLAGS $CLEAN all install)
 
 b_log "Building phoenix-rtos-filesystems"
-(cd phoenix-rtos-filesystems && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-filesystems && make $MAKEFLAGS $CLEAN all)
 b_install "$PREFIX_PROG_STRIPPED/dummyfs" /sbin
 
 b_log "Building phoenix-rtos-devices"
-(cd phoenix-rtos-devices && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-devices && make $MAKEFLAGS $CLEAN all)
 #b_install "$PREFIX_PROG_STRIPPED/imx6ull-gpio" /sbin
 
 b_log "Building phoenix-rtos-usb"
-(cd phoenix-rtos-usb && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-usb && make $MAKEFLAGS $CLEAN all)
 
 b_log "Building coreutils"
-(cd phoenix-rtos-utils && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-utils && make $MAKEFLAGS $CLEAN all)
 b_install "$PREFIX_PROG_STRIPPED"/psh /bin
 b_install "$PREFIX_PROG_STRIPPED"/psd /sbin
 
 #b_log "phoenix-rtos-lwip"
-#(cd phoenix-rtos-lwip && make $MAKEFLAGS "$CLEAN" all)
+#(cd phoenix-rtos-lwip && make $MAKEFLAGS $CLEAN all)
 #b_install "$PREFIX_PROG_STRIPPED/lwip" /sbin
 
 #b_log "Building posixsrv"
-#(cd phoenix-rtos-posixsrv && make $MAKEFLAGS "$CLEAN" all)
+#(cd phoenix-rtos-posixsrv && make $MAKEFLAGS $CLEAN all)
 #b_install "$PREFIX_PROG_STRIPPED/posixsrv" /bin
 
 b_log "Building hostutils"
-(cd phoenix-rtos-hostutils/ && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-hostutils/ && make $MAKEFLAGS $CLEAN all)
 mkdir -p "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/phoenixd" "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/psu" "$PREFIX_BOOT"
 
 b_log "Building phoenix-rtos-corelibs"
-(cd phoenix-rtos-corelibs/ && make $MAKEFLAGS "$CLEAN" all)
+(cd phoenix-rtos-corelibs/ && make $MAKEFLAGS $CLEAN all)


### PR DESCRIPTION
When building target armv7m7-imxrt106x without "clean" option the build breaks:
"make: *** empty string invalid as file name.  Stop."
This is because in build-core-armv7m7-imxrt106x.sh make commands variable
$CLEAN is in quotation marks ("$CLEAN"). Removing them solves the issue.