### PR TITLE
armv7m: section .text=0 and .bss=0x20000000 are not longer obligatory for linker

### DIFF
--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -73,7 +73,6 @@ ifeq ($(KERNEL), 1)
 	LDFLAGS += -Tbss=20000000 -Tdata=20000000
 else
 	CFLAGS += -fpic -fpie -msingle-pic-base -mno-pic-data-is-text-relative
-	LDFLAGS += -e _start --section-start .text=0 -Tbss=20000000
 endif
 
 


### PR DESCRIPTION
This PR is associated with https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/159