### PR TITLE
Add host-pc to accepted platform. Use old hostutils build

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -54,9 +54,14 @@ ifneq (,$(filter $(TARGETS_RISCV64),$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)))
 	TARGET_SUFF ?= riscv64
 endif
 
+TARGETS += host-pc
+ifeq ($(TARGET_FAMILY), host)
+	TARGET_SUFF ?= host
+endif
+
 # Check target
 ifeq (,$(filter $(TARGETS),$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)))
-$(error Incorrect TARGET. Available targets: $(TARGETS))
+$(error Incorrect TARGET $(TARGET_FAMILY)-$(TARGET_SUBFAMILY). Available targets: $(TARGETS))
 endif
 
 #

--- a/Makefile.host
+++ b/Makefile.host
@@ -1,0 +1,38 @@
+#
+# Common Makefile for host
+#
+# Copyright 2018-2021 Phoenix Systems
+#
+# %LICENSE%
+#
+
+CROSS ?=
+
+MKDEP = $(CROSS)gcc -MM
+MKDEPFLAGS = $(CFLAGS)
+
+CC = $(CROSS)gcc
+
+ifeq ($(DEBUG), 1)
+	CFLAGS += -Og
+else
+	CFLAGS += -O2 -DNDEBUG
+endif
+
+CFLAGS += -Wall -Wstrict-prototypes -g -fomit-frame-pointer
+
+AR = $(CROSS)ar
+ARFLAGS = -r
+
+LD = $(CROSS)gcc
+LDFLAGS += -Wl,--gc-sections
+
+OBJCOPY = $(CROSS)objcopy
+OBJDUMP = $(CROSS)objdump
+STRIP = $(CROSS)strip
+
+# Sanitizers
+ifneq ($(NOSAN), 1)
+CFLAGS += -fsanitize=address,undefined
+LDFLAGS += -fsanitize=address,undefined
+endif

--- a/build-core-armv7a7-imx6ull.sh
+++ b/build-core-armv7a7-imx6ull.sh
@@ -50,7 +50,7 @@ b_install $PREFIX_PROG_STRIPPED/psd-old /sbin
 #b_install "$PREFIX_PROG_STRIPPED/posixsrv" /bin
 
 b_log "Building hostutils"
-(cd phoenix-rtos-hostutils/ && make $MAKEFLAGS $CLEAN all)
+(cd phoenix-rtos-hostutils/ && make -f Makefile.old $MAKEFLAGS $CLEAN all)
 cp "$PREFIX_BUILD_HOST/prog.stripped/phoenixd" "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/psu" "$PREFIX_BOOT"
 

--- a/build-core-armv7m7-imxrt106x.sh
+++ b/build-core-armv7m7-imxrt106x.sh
@@ -43,7 +43,7 @@ b_install "$PREFIX_PROG_STRIPPED"/psd /sbin
 #b_install "$PREFIX_PROG_STRIPPED/posixsrv" /bin
 
 b_log "Building hostutils"
-(cd phoenix-rtos-hostutils/ && make $MAKEFLAGS $CLEAN all)
+(cd phoenix-rtos-hostutils/ && make -f Makefile.old $MAKEFLAGS $CLEAN all)
 mkdir -p "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/phoenixd" "$PREFIX_BOOT"
 cp "$PREFIX_BUILD_HOST/prog.stripped/psu" "$PREFIX_BOOT"

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ set -e
 TOPDIR="$(pwd)"
 
 PREFIX_BUILD="$(pwd)/_build/$TARGET"
-PREFIX_BUILD_HOST="$(pwd)/_build/host"
+PREFIX_BUILD_HOST="$(pwd)/_build/host-pc"
 PREFIX_FS="$(pwd)/_fs/$TARGET"
 PREFIX_BOOT="$(pwd)/_boot"
 


### PR DESCRIPTION
I added host-pc target for building code for host with our buildsystem.

Along with this change, I changed hostutils to build using new common Makefile but I preserved the old method for build with build.sh script. To switch to new Makefile, much more changes is required:
1. In phoenix-rtos-build make possible to build for many architecture – env is polluted by exports connected with main TARGET
2. In phoenix-rtos-ports make possible to build without extensive external env – would be great if only TARGET will be needed for normal build.