### PR TITLE
arm: rename arm to armv7a & add build file for zynq-7000

### DIFF
--- a/Makefile.armv7a
+++ b/Makefile.armv7a
@@ -13,9 +13,14 @@ MKDEPFLAGS = $(CFLAGS)
 
 CC = $(CROSS)gcc
 
+
+cpu=cortex-$(shell printf $(TARGET_FAMILY) | tail -c 2)
+
 CFLAGS += -Os -Wall -Wstrict-prototypes -g\
-	-mcpu=cortex-a7 -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -mthumb\
-	-fomit-frame-pointer -mno-unaligned-access -fdata-sections -ffunction-sections
+		-mcpu=$(cpu) -mtune=$(cpu) -mfpu=neon-vfpv4 -mfloat-abi=hard -mthumb\
+		-fomit-frame-pointer -mno-unaligned-access -fdata-sections -ffunction-sections
+
+VADDR_KERNEL_INIT = 0xc0000000
 
 AR = $(CROSS)ar
 ARFLAGS = -r

--- a/Makefile.common
+++ b/Makefile.common
@@ -29,11 +29,12 @@ endif
 
 # ARM Cortex Ax
 TARGETS_ARMCORTEXA = \
-	armv7a7-imx6ull
+	armv7a7-imx6ull \
+	armv7a9-zynq7000
 
 TARGETS += $(TARGETS_ARMCORTEXA)
 ifneq (,$(filter $(TARGETS_ARMCORTEXA),$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)))
-	TARGET_SUFF ?= arm
+	TARGET_SUFF ?= armv7a
 endif
 
 # IA32

--- a/build-core-armv7a9-zynq7000.sh
+++ b/build-core-armv7a9-zynq7000.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Shell script for building Phoenix-RTOS firmware
+#
+# Builder for Phoenix-RTOS core components
+#
+# Copyright 2021 Phoenix Systems
+# Author: Hubert Buczynski
+#
+
+# fail immediately if any of the commands fails
+set -e
+
+b_log "Building phoenix-rtos-kernel"
+KERNEL_MAKECMDGOALS="install-headers"
+(cd phoenix-rtos-kernel && make $MAKEFLAGS $CLEAN $KERNEL_MAKECMDGOALS all)
+
+
+b_log "Building libphoenix"
+#(cd libphoenix && make $MAKEFLAGS $CLEAN all install)
+
+b_log "Building plo"
+(cd plo && make $MAKEFLAGS $CLEAN all)


### PR DESCRIPTION
Changes in this PR are associated with the following PRs:
- https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/184
- https://github.com/phoenix-rtos/libphoenix/pull/78