### PR TITLE
makes: support constructors in static libraries

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -63,9 +63,12 @@ ARCH =  $(SIL)@mkdir -p $(@D); \
 	(printf "AR  %-24s\n" "$(@F)"); \
 	$(AR) $(ARFLAGS) $@ $^ 2>/dev/null
 
-LINK =  $(SIL)mkdir -p $(@D); \
+LDFLAGS_PREFIX :=
+# --whole-archive is needed for linker to always find constructors in .a files
+LINK = $(SIL)mkdir -p $(@D); \
 	(printf "LD  %-24s\n" "$(@F)"); \
-	$(LD) $(LDFLAGS) -o "$@"  $^ $(LDLIBS)
+	$(LD) $(LDFLAGS) -o "$@"  $(LDFLAGS_PREFIX)--whole-archive $^ $(LDFLAGS_PREFIX)--no-whole-archive $(LDLIBS)
+
 
 HEADER = $(SIL)mkdir -p $(@D); \
 	(printf "HEADER %-24s\n" "$<"); \

--- a/Makefile.host
+++ b/Makefile.host
@@ -23,6 +23,7 @@ ARFLAGS = -r
 
 LD = $(CROSS)gcc
 LDFLAGS += -Wl,--gc-sections
+LDFLAGS_PREFIX := -Wl,
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/makes/binary.mk
+++ b/makes/binary.mk
@@ -49,7 +49,8 @@ $(PREFIX_H)%.h: $(LOCAL_DIR)%.h
 
 # rule for linking binary
 # NOTE: if applied globally, we could remove the $(LINK) variable and put explicit commands here
-$(PREFIX_PROG)$(NAME): $(OBJS.$(NAME)) $(RESOLVED_LIBS) $(PHOENIXLIB)
+# NOTE: disabled $(PHOENIXLIB) direct dependency until it can be removed from $(LIBS)
+$(PREFIX_PROG)$(NAME): $(OBJS.$(NAME)) $(RESOLVED_LIBS) # $(PHOENIXLIB)
 	$(LINK)
 
 # create component phony targets


### PR DESCRIPTION
Enable "--whole-archive" while linking our internal libs

JIRA: CI-50