### PR TITLE
Fix invalid passing -mthumb flag

### DIFF
--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -17,8 +17,8 @@ else
   CFLAGS += -O2 -DNDEBUG #-DWATCHDOG
 endif
 
-CFLAGS += -Wall -Wstrict-prototypes -g -I$(SRCDIR)
-CFLAGS += mthumb -fomit-frame-pointer -mno-unaligned-access
+CFLAGS += -Wall -Wstrict-prototypes -g
+CFLAGS += -mthumb -fomit-frame-pointer -mno-unaligned-access
 CFLAGS += -DNOMMU
 CFLAGS += -fdata-sections -ffunction-sections
 


### PR DESCRIPTION
-I${SRCDIR} with empty {SRCDIR} causes that -Imthumb was passed. 
-mthumb are without leading, so invalid too.

Remove unneeded -I and fix mthumb.