### PR TITLE
host-pc: add building corelibs

### DIFF
--- a/build-core-host-pc.sh
+++ b/build-core-host-pc.sh
@@ -14,6 +14,9 @@ set -e
 b_log "Building libphoenix"
 make -C "libphoenix" -f Makefile.host all
 
+b_log "Building phoenix-rtos-corelibs"
+make -C "phoenix-rtos-corelibs" all install
+
 b_log "Building phoenix-rtos-filesystems"
 make -C "phoenix-rtos-filesystems" all
 


### PR DESCRIPTION
## Description

Add building corelibs for host-pc target.

## Motivation and Context

It's required for rotating rectangle example in user space.
JIRA: PD-119

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (ia32-generic - qemu).

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
