### PR TITLE
imxrt: revert linking crtbegin.o/crtend.o

### DIFF
--- a/Makefile.armv7a
+++ b/Makefile.armv7a
@@ -25,10 +25,8 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS = -z max-page-size=0x1000 --gc-sections
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
-CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
-CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -75,10 +75,8 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
-CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
-CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.ia32
+++ b/Makefile.ia32
@@ -21,10 +21,8 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS := --gc-sections
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
-CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
-CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -22,10 +22,8 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS :=
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
-CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
-CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump


### PR DESCRIPTION
The change causes apps on imxrt to crash after second launch.
This reverts commit ef8a1166499d7dc3a925ffab5b26e70976ef6f43.

DONE: BES-169

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
The commit ef8a116 introduces problems in imxrt106x, causing apps to reset system after invoking sysexec 2 times.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reverting commit ef8a116 fixes problem with launching apps using sysexec for imxrt platform based projects.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m7-imxrt106x).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
