### PR TITLE
build: remove tests building from core

### DIFF
--- a/build-core-host-pc.sh
+++ b/build-core-host-pc.sh
@@ -19,7 +19,3 @@ make -C "phoenix-rtos-filesystems" all
 
 b_log "Building phoenix-rtos-devices"
 make -C "phoenix-rtos-devices" all
-
-#FIXME: tests should not always be built as a part of CORE
-b_log "Building phoenix-rtos-tests"
-make -C "phoenix-rtos-tests" all

--- a/build-core-ia32-generic.sh
+++ b/build-core-ia32-generic.sh
@@ -30,10 +30,6 @@ make -C "phoenix-rtos-devices" all install
 b_log "Building coreutils"
 make -C "phoenix-rtos-utils" all install
 
-#FIXME: tests should not always be built as a part of CORE
-b_log "Building phoenix-rtos-tests"
-make -C "phoenix-rtos-tests" all
-
 #b_log "Building phoenix-rtos-lwip"
 #make -C "phoenix-rtos-lwip" all
 #b_install "$PREFIX_PROG_STRIPPED/lwip" /sbin


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Now tests for `ia32-generic` and `host-pc` are partially build as a `core` target. As there is a `test` target there is no need to further use of the `core`.

Changes won't break CI - in the `test` target make with `install` is invoked which is now equivalent to `all install`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [X] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: (ia32-generic, host-pc).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [X] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
