### PR TITLE
scripts: Fix stm32l4 program script

### DIFF
--- a/scripts/program-stm32l4x6.sh
+++ b/scripts/program-stm32l4x6.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-OPENOCDPATH="/usr/local/share/openocd"
-
-openocd -f $OPENOCDPATH/scripts/interface/stlink.cfg -f $OPENOCDPATH/scripts/target/stm32l4x.cfg -c "reset_config srst_only srst_nogate connect_assert_srst"  -c"program $1 0x08000000 verify reset exit"
+openocd -f interface/stlink.cfg -f target/stm32l4x.cfg -c "reset_config srst_only srst_nogate connect_assert_srst"  -c"program $1 0x08000000 verify reset exit"
 
 exit 0


### PR DESCRIPTION
program script uses absolute predefined path to opemocd scripts before.
Now it will be relative to openocd installation.

JIRA: ISC-118

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
To have openocd support for new hardware you have to compile it from sources as releases are too rare. Standard path for local builds is /usr/local but it don't have to be there. This patch changes hardcoded path to relative from binary (it's auto resolved by openocd)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Change fixes script error in my environment where openocd is self compiled in another directory. 
Also, possible to system installed openocd on newest distros (on 7.03 openocd 0.11.0 with support of new cpus and programmers are was released)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m4-stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
