### PR TITLE
build: add NDEBUG, add /tmp creation by default

### DIFF
--- a/Makefile.armv7a
+++ b/Makefile.armv7a
@@ -8,12 +8,17 @@
 
 CROSS ?= arm-phoenix-
 
-CC = $(CROSS)gcc
+CC := $(CROSS)gcc
 
+ifeq ($(DEBUG), 1)
+  CFLAGS += -Og
+else
+  CFLAGS += -O2 -DNDEBUG
+endif
 
 cpu := cortex-$(subst armv7,,$(TARGET_FAMILY))
 
-CFLAGS += -Os -Wall -Wstrict-prototypes -g\
+CFLAGS += -Wall -Wstrict-prototypes -g\
 		-mcpu=$(cpu) -mtune=$(cpu) -mfpu=neon-vfpv4 -mfloat-abi=hard -mthumb\
 		-fomit-frame-pointer -mno-unaligned-access -fdata-sections -ffunction-sections
 

--- a/Makefile.ia32
+++ b/Makefile.ia32
@@ -8,9 +8,15 @@
 
 CROSS ?= i386-pc-phoenix-
 
-CC = $(CROSS)gcc
+CC := $(CROSS)gcc
 
-CFLAGS += -O2 -g -Wall -Wstrict-prototypes\
+ifeq ($(DEBUG), 1)
+  CFLAGS += -Og
+else
+  CFLAGS += -O2 -DNDEBUG
+endif
+
+CFLAGS += -g -Wall -Wstrict-prototypes\
 	-m32 -march=i586 -mtune=generic -mno-mmx -mno-sse -fno-pic -fno-pie\
 	-fomit-frame-pointer -fno-builtin-malloc\
 	-fdata-sections -ffunction-sections

--- a/build.sh
+++ b/build.sh
@@ -118,7 +118,7 @@ if [ "${B_FS}" = "y" ] && [ -d  "${PREFIX_ROOTSKEL}" ]; then
 
 	mkdir -p "${PREFIX_ROOTFS}"
 	cp -a "${PREFIX_ROOTSKEL}/." "${PREFIX_ROOTFS}"
-	mkdir -p "$PREFIX_ROOTFS/"{dev,local,data,mnt,var}
+	mkdir -p "$PREFIX_ROOTFS/"{dev,local,data,mnt,tmp,var}
 
 	b_log "Saving git-version"
 	install -m 664 "${PREFIX_BUILD}/git-version" "$PREFIX_FS/root/etc"


### PR DESCRIPTION
## Description
Stop-gap for phoenix-rtos/phoenix-rtos-project#138

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
- [ ] Tested by hand on: `imx6ull`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.