### PR TITLE
armv7m7-imxrt106x: Build lwip by default

### DIFF
--- a/build-core-armv7m7-imxrt106x.sh
+++ b/build-core-armv7m7-imxrt106x.sh
@@ -30,9 +30,8 @@ make -C "phoenix-rtos-usb" all install
 b_log "Building coreutils"
 make -C "phoenix-rtos-utils" all install
 
-#b_log "phoenix-rtos-lwip"
-#make -C "phoenix-rtos-lwip" all
-#b_install "$PREFIX_PROG_STRIPPED/lwip" /sbin
+b_log "phoenix-rtos-lwip"
+make -C "phoenix-rtos-lwip" all install
 
 #b_log "Building posixsrv"
 #make -C "phoenix-rtos-posixsrv" all install


### PR DESCRIPTION
JIRA: BES-177

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change causes lwip to be built by default.

## Motivation and Context
We use lwip in at least two projects on imxrt1064, using different drivers, so it has already been proven to be working. We should build it by default.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imxrt1064).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
