### PR TITLE
Revert "imxrt: revert linking crtbegin.o/crtend.o"

### DIFF
--- a/Makefile.armv7a
+++ b/Makefile.armv7a
@@ -30,8 +30,10 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS = -z max-page-size=0x1000 --gc-sections
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
+CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -75,8 +75,10 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
+CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.ia32
+++ b/Makefile.ia32
@@ -27,8 +27,10 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS := --gc-sections
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
+CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -22,8 +22,10 @@ ARFLAGS = -r
 LD = $(CROSS)ld
 LDFLAGS :=
 GCCLIB := $(shell $(CC) $(CFLAGS) -print-libgcc-file-name)
+CRTBEGIN := $(shell $(CC) $(CFLAGS) -print-file-name=crtbegin.o)
+CRTEND := $(shell $(CC) $(CFLAGS) -print-file-name=crtend.o)
 PHOENIXLIB := $(shell $(CC) $(CFLAGS) -print-file-name=libphoenix.a)
-LDLIBS := $(PHOENIXLIB) $(GCCLIB)
+LDLIBS := $(PHOENIXLIB) $(GCCLIB) $(CRTBEGIN) $(CRTEND)
 
 OBJCOPY = $(CROSS)objcopy
 OBJDUMP = $(CROSS)objdump


### PR DESCRIPTION
This reverts commit 8744ba3bba8f3c5935f2945e92d8a2065bc59e83.

New toolchain builds crtstuff from gcc with -fPIC option so no absoulte
relocation in data section occurs, so issues on imxrt platforms should
not occur now.

This commit is workaround for stm32l4x6 targets with invalid place of
_init/fini_array_start/end symbols when _init/fini_array is empty.

JIRA: ISC-118

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reverts the revert  which was needed due to issues on imxrt platform with absolute reloations connected with crtstuff. With new toolchain builds all should work as expected

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is workaround for issue probably in linker/linker script.
When init/fini array is empty sometimes it's outside the data segment and kernel cannot do relocation on this symbol. 

Example content of program section and _fini_array_address:

```
Elf file type is EXEC (Executable file)
Entry point 0x142e9
There are 3 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  EXIDX          0x012f5c 0x0001aebc 0x0001aebc 0x00008 0x00008 R   0x4
  LOAD           0x0000a0 0x00008000 0x00008000 0x12ec4 0x12ec4 R E 0x10
  LOAD           0x012f68 0x0001aed8 0x0001aed8 0x007c0 0x01af0 RW  0x10

 Section to Segment mapping:
  Segment Sections...
   00     .ARM.exidx 
   01     .text .rodata .ARM.exidx 
   02     .data.rel.ro .got .data .bss 

```
```
  1623: 0001aed4     0 NOTYPE  LOCAL  DEFAULT    6 __fini_array_end
  1624: 0001aed4     0 NOTYPE  LOCAL  DEFAULT    6 __fini_array_start
  2072: 00017149    44 FUNC    GLOBAL DEFAULT    1 _fini_array

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

:warning: With this commit you are obliged to use new toolchain when building application on imxrt!
<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (stm32l4x6).

Broken binary, compiled with this commit contain non-empty _init/fini_array and issues there are no longer issue with relocation.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
