### PR TITLE
makes: fix headers install rule to be applied only for chosen headers

### DIFF
--- a/makes/binary.mk
+++ b/makes/binary.mk
@@ -44,7 +44,7 @@ ifneq ($(filter-out $(PREFIX_H)%, $(INSTALLED_HEADERS.$(NAME))),)
   $(error $(NAME): Installing headers outside of PREFIX_H, check Your makefile: $(INSTALLED_HEADERS.$(NAME)))
 endif
 
-$(PREFIX_H)%.h: $(LOCAL_DIR)%.h
+$(INSTALLED_HEADERS.$(NAME)): $(PREFIX_H)%.h: $(LOCAL_DIR)%.h
 	$(HEADER)
 
 # rule for linking binary

--- a/makes/static-lib.mk
+++ b/makes/static-lib.mk
@@ -40,7 +40,7 @@ ifneq ($(filter-out $(PREFIX_H)%, $(INSTALLED_HEADERS.$(NAME))),)
   $(error $(NAME): Installing headers outside of PREFIX_H, check Your makefile: $(INSTALLED_HEADERS.$(NAME)))
 endif
 
-$(PREFIX_H)%.h: $(LOCAL_DIR)%.h
+$(INSTALLED_HEADERS.$(NAME)): $(PREFIX_H)%.h: $(LOCAL_DIR)%.h
 	$(HEADER)
 
 # allow header-only components


### PR DESCRIPTION
## Description
In case we have the same file names on different dirs and we want to
install one of them in PREFIX_H, the file to be installed was decided on
sub-Makefile include order.

The error was caught during CI build:
https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/139/checks?check_run_id=3677396404

(while building `imx6ull` `i2c.h` is being installed from `multi/stm32l1-multi/i2c.h` instead of `i2c/common/i2c.h`)

## Motivation and Context
JIRA: DTR-152

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing (CI builds)
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
