### PR TITLE
build-toolchain: changed list of files to strip

### DIFF
--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -184,9 +184,11 @@ build_gcc_stage2() {
 
 strip_binaries() {
     log "stripping binaries"
-    for bin in "$TOOLCHAIN_PREFIX"/bin/*; do
-        strip "$bin"
-    done
+    if [ "$(uname)" = "Darwin" ]; then
+        find "$TOOLCHAIN_PREFIX" -type f -perm +111 -exec strip {} + || true
+    else
+        find "$TOOLCHAIN_PREFIX" -type f -perm /111 -exec strip {} + || true
+    fi
 
     # NOTE: we could also strip target libraries, but let's leave debug sections for ease of development
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
I looked through the `build-toolchain.sh` script and noticed that `strip` is executed only for files in the `bin` directory.
However in the `libexec/gcc/<target>/9.3.0` directory there are files which significantly affect the size of the toolchain e.g.
```
ls -l arm-phoenix/libexec/gcc/arm-phoenix/9.3.0
-rwxrwxrwx 1 root root 216M Aug 24 13:15 cc1
-rwxrwxrwx 1 root root 227M Aug 24 13:15 cc1plus
-rwxrwxrwx 1 root root 4.1M Aug 24 13:15 collect2
drwxrwxrwx 2 root root 4.0K Aug 24 13:15 install-tools
-rwxrwxrwx 1 root root 1005 Aug 24 13:15 liblto_plugin.la
lrwxrwxrwx 1 root root   22 Aug 24 13:15 liblto_plugin.so -> liblto_plugin.so.0.0.0
lrwxrwxrwx 1 root root   22 Aug 24 13:15 liblto_plugin.so.0 -> liblto_plugin.so.0.0.0
-rwxrwxrwx 1 root root 443K Aug 24 13:15 liblto_plugin.so.0.0.0
-rwxrwxrwx 1 root root 5.7M Aug 24 13:15 lto-wrapper
-rwxrwxrwx 1 root root 208M Aug 24 13:15 lto1
drwxrwxrwx 2 root root 4.0K Aug 24 13:15 plugin
```
`cc1, cc1plus, lto1` files are over `200M` each.
By performing a `strip` on the files in this directory, you can significantly reduce the size of the toolchain space on disk.

I did a test in the `phoenixrtos/build image`.
For each `TARGET` I ran `find <target> -type f -perm -111 -exec strip {} +`
Results:
```
                  current  striped
arm-phoenix          1.3G     747M
i386-pc-phoenix      808M     157M
riscv64-phoenix      661M     135M
/opt                 2.8G     1.1G
```
Looking at the results shown above by performing `strip` on the remaining files that have the `x` attribute set can reduce the `docker image` size by about **1.7G.**

This PR performs a `strip` on all files that have any of  the `x` permission bits mode set for the file.
I tested for `Linux` and `TARGET=i386-pc-phoenix`. For `Mac OSX` it should work but I have not tested it.

You can use `-perm -111` ( all of the `x` permission bits mode are set for the file, in this case, same efect ) and the `Linux` and `Mac OSX` versions will be the same.
```
find "$TOOLCHAIN_PREFIX" -type f -perm -111 -exec strip {} + || true
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
