### PR TITLE
Makefile: riscv: add DEBUG variable check

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -12,8 +12,14 @@ CROSS ?= riscv64-phoenix-
 
 CC = $(CROSS)gcc
 
+ifeq ($(DEBUG), 1)
+  CFLAGS += -Og
+else
+  CFLAGS += -O2 -DNDEBUG
+endif
+
 # FIXME: -ffunction-sections and -fdata-sections are missing
-CFLAGS += -O2 -Wall -Wstrict-prototypes\
+CFLAGS += -Wall -Wstrict-prototypes\
 	-fomit-frame-pointer -mcmodel=medany -fno-builtin -DTARGET_RISCV64
 
 AR = $(CROSS)ar


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Makefile: riscv: add DEBUG variable check
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Documentation, including quickstarts need to be updated. There is a problem with running riscv-spike image using spike simulator. The user stack corrupted error occurs then. This change doesn't solve some known problem with kernel (fix is in progress), but the problem isn't invoked, when NDEBUG is set (building without debug option).

![Screenshot from 2021-11-02 17-59-56](https://user-images.githubusercontent.com/77304431/139911370-dc921063-efe8-457f-a548-e5f375133475.png)

JIRA: PD-206

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (riscv64-spike, riscv64-virt).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
