### PR TITLE
armv7m4-stm32l4x6: Build libdummyfs before devices

### DIFF
--- a/build-core-armv7m4-stm32l4x6.sh
+++ b/build-core-armv7m4-stm32l4x6.sh
@@ -21,11 +21,11 @@ make -C "libphoenix" all install
 b_log "Building phoenix-rtos-corelibs"
 make -C "phoenix-rtos-corelibs" all install
 
-b_log "Building phoenix-rtos-devices"
-make -C "phoenix-rtos-devices" all
-
 b_log "Building phoenix-rtos-filesystems"
 make -C "phoenix-rtos-filesystems" all
+
+b_log "Building phoenix-rtos-devices"
+make -C "phoenix-rtos-devices" all
 
 b_log "Building coreutils"
 make -C "phoenix-rtos-utils" all


### PR DESCRIPTION
JIRA: ISC-126

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change is needed in order to build `phoenix-rtos-devices` repo after merging: https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/152

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
