### PR TITLE
makes: cflags: remove local dev path from macros

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -70,6 +70,9 @@ endif
 # generic CFLAGS/LDFLAGS
 LDFLAGS += -L$(PREFIX_A)
 
+# remove local dev path from macros
+CFLAGS += -fmacro-prefix-map=$(dir $(TOPDIR))=
+
 ifneq ($(KERNEL), 1)
   CFLAGS += -I$(PREFIX_H)
 endif


### PR DESCRIPTION
## Description
This makes `__FILE__` macro being stripped from
/my/fancy/local/dir/phoenix-rtos-kernel/syscalls.c ->
/phoenix-rtos-kernel/syscalls.c

(please note that debug paths in unstripped binaries are unaffected for
ease of use with GDB, for more repetitive builds we would need to change
that).

## Motivation and Context
JIRA: CI-98

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `imx6ull`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
