### PR TITLE
makes: Add OLVL to change optimisation level

### DIFF
--- a/Makefile.armv7a
+++ b/Makefile.armv7a
@@ -10,11 +10,8 @@ CROSS ?= arm-phoenix-
 
 CC := $(CROSS)gcc
 
-ifeq ($(DEBUG), 1)
-  CFLAGS += -Og
-else
-  CFLAGS += -O2 -DNDEBUG
-endif
+OLVL ?= -O2
+CFLAGS += $(OLVL)
 
 cpu := cortex-$(subst armv7,,$(TARGET_FAMILY))
 

--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -11,12 +11,8 @@ CROSS ?= arm-phoenix-
 CC := $(CROSS)gcc
 
 # common Cortex-M CFLAGS
-ifeq ($(DEBUG), 1)
-  CFLAGS += -Og
-else
-  CFLAGS += -O2 -DNDEBUG #-DWATCHDOG
-endif
-
+OLVL ?= -O2
+CFLAGS += $(OLVL)
 CFLAGS += -Wall -Wstrict-prototypes -g
 CFLAGS += -mthumb -fomit-frame-pointer -mno-unaligned-access
 CFLAGS += -DNOMMU

--- a/Makefile.common
+++ b/Makefile.common
@@ -24,6 +24,18 @@ CFLAGS :=
 LDFLAGS :=
 LDFLAGS_PREFIX :=
 
+# specific "-Ox" flag can be set globally for project by setting OLVL variable
+ifneq ($(filter-out -O%,$(OLVL)),)
+  $(error OLVL set but does not provide optimisation flags)
+endif
+
+# for debug build always use -Og optimisation
+ifeq ($(DEBUG), 1)
+  OLVL := -Og
+else
+  CFLAGS += -DNDEBUG
+endif
+
 TOPDIR := $(CURDIR)
 PREFIX_BUILD ?= ../_build/$(TARGET)
 PREFIX_BUILD := $(abspath $(PREFIX_BUILD))

--- a/Makefile.host
+++ b/Makefile.host
@@ -10,12 +10,8 @@ CROSS ?=
 
 CC = $(CROSS)gcc
 
-ifeq ($(DEBUG), 1)
-	CFLAGS += -Og
-else
-	CFLAGS += -O2 -DNDEBUG
-endif
-
+OLVL ?= -O2
+CFLAGS += $(OLVL)
 CFLAGS += -Wall -Wstrict-prototypes -g -fomit-frame-pointer -ffunction-sections -fdata-sections
 
 AR = $(CROSS)ar

--- a/Makefile.ia32
+++ b/Makefile.ia32
@@ -10,12 +10,8 @@ CROSS ?= i386-pc-phoenix-
 
 CC := $(CROSS)gcc
 
-ifeq ($(DEBUG), 1)
-  CFLAGS += -Og
-else
-  CFLAGS += -O2 -DNDEBUG
-endif
-
+OLVL ?= -O2
+CFLAGS += $(OLVL)
 CFLAGS += -g -Wall -Wstrict-prototypes\
 	-m32 -march=i586 -mtune=generic -mno-mmx -mno-sse -fno-pic -fno-pie\
 	-fomit-frame-pointer -fno-builtin-malloc\

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -12,12 +12,8 @@ CROSS ?= riscv64-phoenix-
 
 CC = $(CROSS)gcc
 
-ifeq ($(DEBUG), 1)
-  CFLAGS += -Og
-else
-  CFLAGS += -O2 -DNDEBUG
-endif
-
+OLVL ?= -O2
+CFLAGS += $(OLVL)
 # FIXME: -ffunction-sections and -fdata-sections are missing
 CFLAGS += -Wall -Wstrict-prototypes -g\
 	-fomit-frame-pointer -mcmodel=medany -fno-builtin -DTARGET_RISCV64


### PR DESCRIPTION
Default optimisation level can be overwritten by build.project by
defining OLVL variable.
It is required for some targets to define Os instead of default O2
level to decrease flashimg size.

JIRA: ISC-164

<!--- Provide a general summary of your changes in the Title above -->
Add new parameter OLVL which accepts -O flags. All other flags is filtered. This allows to change optimisation level of whole system from project configuration.
## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: build only and build log analysis armv7m7-imxrt106x armv7a9-zynq7000 armv7a7-imx6ull armv7m4-stm32l4x6

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
