### PR TITLE
makes: Add script wrapping strip

### DIFF
--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -62,7 +62,7 @@ else
   CFLAGS += -fpic -fpie -msingle-pic-base -mno-pic-data-is-text-relative
 	# output .rel.* sections to make ELF position-independent
   LDFLAGS += -q
-  STRIP = $(CROSS)strip --strip-unneeded
+  STRIP = $(PREFIX_PROJECT)/phoenix-rtos-build/scripts/strip.py $(CROSS)strip --strip-unneeded -R .rel.text
 endif
 
 

--- a/Makefile.common
+++ b/Makefile.common
@@ -156,4 +156,4 @@ $(PREFIX_O)%.o: %.S
 $(PREFIX_PROG_STRIPPED)%: $(PREFIX_PROG)%
 	@mkdir -p $(@D)
 	@printf "STR %-24s\n" "$(@F)"
-	$(SIL)$(STRIP) --strip-unneeded -o $@ $<
+	$(SIL)$(STRIP) -o $@ $<

--- a/scripts/strip.py
+++ b/scripts/strip.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+#
+# Script to remove references to .symtab from relocation section and then run strip
+#
+# Copyright 2022 Phoenix Systems
+# Author: Andrzej Glowinski
+#
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from io import BytesIO
+from dataclasses import dataclass
+from enum import IntEnum
+import struct
+from typing import ClassVar, Type, List, Tuple
+
+
+class EiClass(IntEnum):
+    """EI_CLASS field from e_ident that determines if elf is 32 or 64-bit"""
+    ELFCLASSNONE = 0
+    ELFCLASS32 = 1
+    ELFCLASS64 = 2
+
+
+class EiData(IntEnum):
+    """EI_DATA field from e_ident that determines if elf is little or big endian"""
+    ELFDATANONE = 0
+    ELFDATA2LSB = 1
+    ELFDATA2MSB = 2
+
+    def to_format(self):
+        return {EiData.ELFDATA2LSB: "<", EiData.ELFDATA2MSB: ">"}[self]
+
+
+# Types only needed for resolving relocations
+class ShType(IntEnum):
+    """Interpretation of sh_type field of ElfXX_Shdr struct. Determines section type"""
+    SHT_NULL = 0
+    SHT_RELA = 4
+    SHT_REL = 9
+
+
+class ElfStruct:
+    """Abstract for every ELF struct"""
+    FORMAT: ClassVar[List[Tuple[str, str]]]
+
+    @classmethod
+    def parse(cls, b: bytes, e: EiData):
+        data = struct.unpack(e.to_format() + cls._get_format(), b)
+        return cls(**dict(zip(cls._get_params(), data)))
+
+    def serialize(self, e: EiData):
+        return struct.pack(e.to_format() + self._get_format(), *(getattr(self, name) for name in self._get_params()))
+
+    @property
+    def size(self):
+        return self.get_size()
+
+    @classmethod
+    def get_size(cls):
+        return struct.calcsize(f"={cls._get_format()}")
+
+    @classmethod
+    def _get_format(cls):
+        return ''.join(tuple(zip(*cls.FORMAT))[0])
+
+    @classmethod
+    def _get_params(cls):
+        return tuple(zip(*cls.FORMAT))[1]
+
+
+@dataclass
+class ElfEident:
+    """ElfXX_Ehdr e_ident field"""
+    e_ident: bytes
+
+    def get_class(self):
+        return EiClass(self.e_ident[4])
+
+    def get_endianness(self):
+        return EiData(self.e_ident[5])
+
+    @classmethod
+    def parse(cls, b: bytes) -> "ElfEident":
+        return cls(*struct.unpack("16s", b))
+
+    def __post_init__(self):
+        if self.e_ident[0:4] != b"\x7fELF":
+            raise ValueError(f"ELF magic invalid: {self.e_ident[0:4]}")
+        if self.get_class() != EiClass.ELFCLASS32:
+            raise NotImplementedError("Only 32 bit ELF files is supported")
+
+
+@dataclass
+class ElfEhdr(ElfStruct):
+    """Abstraction for structs Elf32_Ehdr and Elf64_Ehdr"""
+    e_type: int
+    e_machine: int
+    e_version: int
+    e_entry: int
+    e_phoff: int
+    e_shoff: int
+    e_flags: int
+    e_ehsize: int
+    e_phentsize: int
+    e_phnum: int
+    e_shentsize: int
+    e_shnum: int
+    e_shstrndx: int
+
+
+@dataclass
+class Elf32Ehdr(ElfEhdr):
+    """struct Elf32_Ehdr without e_ident field"""
+    FORMAT = [
+        ("H", "e_type"),
+        ("H", "e_machine"),
+        ("I", "e_version"),
+        ("I", "e_entry"),
+        ("I", "e_phoff"),
+        ("I", "e_shoff"),
+        ("I", "e_flags"),
+        ("H", "e_ehsize"),
+        ("H", "e_phentsize"),
+        ("H", "e_phnum"),
+        ("H", "e_shentsize"),
+        ("H", "e_shnum"),
+        ("H", "e_shstrndx")
+    ]
+
+
+@dataclass
+class ElfShdr(ElfStruct):
+    """Abstraction for structs Elf32_Shdr and Elf64_Shdr"""
+    sh_name: int
+    sh_type: int
+    sh_flags: int
+    sh_addr: int
+    sh_offset: int
+    sh_size: int
+    sh_link: int
+    sh_info: int
+    sh_addralign: int
+    sh_entsize: int
+
+
+@dataclass
+class Elf32Shdr(ElfShdr):
+    """struct Elf32_Shdr"""
+    FORMAT = [
+        ("I", "sh_name"),
+        ("I", "sh_type"),
+        ("I", "sh_flags"),
+        ("I", "sh_addr"),
+        ("I", "sh_offset"),
+        ("I", "sh_size"),
+        ("I", "sh_link"),
+        ("I", "sh_info"),
+        ("I", "sh_addralign"),
+        ("I", "sh_entsize")
+    ]
+
+
+@dataclass
+class ElfRelx(ElfStruct):
+    """Abstraction for structs Elf32_Rel, Elf64_Rel, Elf32_Rela, Elf64_Rela"""
+    r_offset: int
+    r_info: int
+
+
+@dataclass
+class Elf32Rel(ElfRelx):
+    """struct Elf32_Rel"""
+    FORMAT = [
+        ("I", "r_offset"),
+        ("I", "r_info")
+    ]
+
+
+class ElfFixedSizeTable:
+    offset: int
+    size: int
+    entrySize: int
+    header: Type[ElfStruct]
+    parser: "ElfParser"
+
+    def __init__(self, p: "ElfParser"):
+        self.parser = p
+
+    def __iter__(self):
+        for off in range(self.offset, self.offset + self.size, self.entrySize):
+            assert self.entrySize == self.header.get_size()
+            yield self.parser.read_struct(self.header, off), off
+
+
+class ElfSectionTable(ElfFixedSizeTable):
+    header: Type[ElfShdr]
+
+    def __init__(self, e: ElfEhdr, p: "ElfParser"):
+        super().__init__(p)
+        self.header = {EiClass.ELFCLASS32: Elf32Shdr}[p.ident.get_class()]
+        self.offset = e.e_shoff
+        self.size = e.e_shnum * e.e_shentsize
+        self.entrySize = e.e_shentsize
+
+
+class ElfRelocationTable(ElfFixedSizeTable):
+    header: Type[ElfRelx]
+
+    def __init__(self, s: ElfShdr, p: "ElfParser"):
+        super().__init__(p)
+        self.header = {(EiClass.ELFCLASS32, ShType.SHT_REL): Elf32Rel}[p.ident.get_class(), ShType(s.sh_type)]
+        self.offset = s.sh_offset
+        self.size = s.sh_size
+        self.entrySize = s.sh_entsize
+
+
+class ElfParser:
+    data: BytesIO
+    ident: ElfEident
+    header: ElfEhdr
+
+    def __init__(self, b: BytesIO):
+        self.data = b
+        self.ident = ElfEident.parse(self.data.read(16))
+        header_type = {EiClass.ELFCLASS32: Elf32Ehdr}[self.ident.get_class()]
+        header = self.read_struct(header_type, 16)
+        assert isinstance(header, ElfEhdr)
+        self.header = header
+
+    def read_struct(self, st: Type[ElfStruct], offset):
+        self.data.seek(offset)
+        data = self.data.read(st.get_size())
+        return st.parse(data, self.ident.get_endianness())
+
+    def write_struct(self, st: ElfStruct, offset):
+        self.data.seek(offset)
+        self.data.write(st.serialize(self.ident.get_endianness()))
+
+    def get_sections(self) -> ElfSectionTable:
+        return ElfSectionTable(self.header, self)
+
+    def get_relocations(self, s: ElfShdr) -> ElfRelocationTable:
+        return ElfRelocationTable(s, self)
+
+
+def remove_symtab_references(in_file, out_file):
+    with open(in_file, "rb") as file:
+        shutil.copyfileobj(file, out_file)
+    out_file.seek(0)
+
+    elf = ElfParser(out_file)
+    for s, _ in elf.get_sections():
+        # Get sections connected with relocations
+        if s.sh_type in (ShType.SHT_REL, ShType.SHT_RELA):
+            # Iterate over relocations
+            for r, r_off in elf.get_relocations(s):
+                # r_info field of Rel(a) struct contain both relocation type (on LSB) and symbol table index on rest.
+                # Preserve relocation type but set symbol table index to 0 (STN_UNDEF) for each relocation
+                r.r_info &= 0xff
+                elf.write_struct(r, r_off)
+
+
+def validate_args():
+    return not sys.argv[1].startswith("-") and "-o" in sys.argv[2:-2]
+
+
+def strip_wrapper():
+    # Many input files without -o on strip call is not supported by this wrapper
+    if not validate_args():
+        print(f"Usage: {sys.argv[0]} strip_binary <strip options> -o out_file in_file", file=sys.stderr)
+        sys.exit(1)
+
+    in_file = sys.argv[-1]
+    with tempfile.NamedTemporaryFile() as tmp_file:
+        remove_symtab_references(in_file, tmp_file)
+        tmp_file.flush()
+        subprocess.check_call([*sys.argv[1:-1], tmp_file.name])
+
+
+if __name__ == '__main__':
+    strip_wrapper()


### PR DESCRIPTION
Relocation sections have references to symtab, which is not needed for
relocation process in kernel. Script is needed for remove this
refferences to allow strip removing symtab

Also it removes rel.text entirely as it's not needed

JIRA: ISC-129

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add strip wrapper to remove references from relocation sections to symtab and then run strip
This way it allows strip to removal of big symtab.

armv7m targets will use this strip wrapper to produce stripped binaries

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed for decreasing binary size on NOMMU targets that perform dynamic relocation in kernel.

Some statistics and infos below:
1. Differnces with size:
- armv7m4-stm32l4x6

| Program  | Current | Removal only .rel.text | Removal with script |
| ------------- | ------------- | ------------- | ------------- |
| phoenix-armv7m4-stm32l4x6.disk  | 298432  | 268612 | 236840 |
| psh | 120768  | 101188 | 80168 |
| stm32l4-multi | 63992  | 53644 | 42744 |
| hello | 10368  | 9068 | 6296 |

- armv7m7-imxrt106x

| Program  | Current | Removal only .rel.text | Removal with script |
| ------------- | ------------- | ------------- | ------------- |
| phoenix-armv7m7-imxrt106x.disk  | 360716  | 326712 | 286024 |
| psh | 116004  | 97016 | 76648 |
| imxrt-multi | 33672  | 29420 |  23228 |
| imxrt-flash | 39180  | 34360 |  27464 |
| lwip | 213500 | 182688 |  148188 |
| hello | 10432 | 9132 | 6360 |

2. Differences wtih sections (on psh binary for armv7m4-stm32l4x6):
-   Without script
```
readelf -S _build/armv7m4-stm32l4x6/prog.stripped/psh 
There are 23 section headers, starting at offset 0x1ddf8:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00008000 0000c0 00fe28 00  AX  0   0  8
  [ 2] .rel.text         REL             00000000 018b0c 004de8 08   I 20   1  4
  [ 3] .rodata           PROGBITS        00017e28 00fee8 002a95 00   A  0   0  4
  [ 4] .ARM.exidx        ARM_EXIDX       0001a8c0 012980 000008 00  AL  1   0  4
  [ 5] .rel.ARM.exidx    REL             00000000 01d8f4 000008 08   I 20   4  4
  [ 6] .eh_frame         PROGBITS        0001a8c8 012988 000004 00   A  0   0  4
  [ 7] .init_array       INIT_ARRAY      0001a8dc 01298c 000078 04  WA  0   0  4
  [ 8] .rel.init_array   REL             00000000 01d8fc 0000f0 08   I 20   7  4
  [ 9] .fini_array       FINI_ARRAY      0001a954 012a04 000004 04  WA  0   0  4
  [10] .rel.fini_array   REL             00000000 01d9ec 000008 08   I 20   9  4
  [11] .data.rel.ro      PROGBITS        0001a958 012a08 0000e8 00  WA  0   0  4
  [12] .rel.data.rel.ro  REL             00000000 01d9f4 000178 08   I 20  11  4
  [13] .got              PROGBITS        0001aa40 012af0 000950 04  WA  0   0  4
  [14] .data             PROGBITS        0001b390 013440 00030c 00  WA  0   0  4
  [15] .rel.data         REL             00000000 01db6c 0001e0 08   I 20  14  4
  [16] .bss              NOBITS          0001b69c 01374c 0009d0 00  WA  0   0  4
  [17] .comment          PROGBITS        00000000 01374c 000011 01  MS  0   0  1
  [18] .ARM.attributes   ARM_ATTRIBUTES  00000000 01375d 00002c 00      0   0  1
  [19] .noinit           PROGBITS        0001c06c 013789 000000 00   W  0   0  1
  [20] .symtab           SYMTAB          00000000 01378c 003e90 10     21 649  4
  [21] .strtab           STRTAB          00000000 01761c 0014f0 00      0   0  1
  [22] .shstrtab         STRTAB          00000000 01dd4c 0000ac 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  D (mbind), y (purecode), p (processor specific)
```
-   With script
```
readelf -S _build/armv7m4-stm32l4x6/prog.stripped/psh 
There are 20 section headers, starting at offset 0x13c7c:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00008000 0000c0 00fe28 00  AX  0   0  8
  [ 2] .rodata           PROGBITS        00017e28 00fee8 002a95 00   A  0   0  4
  [ 3] .ARM.exidx        ARM_EXIDX       0001a8c0 012980 000008 00  AL  1   0  4
  [ 4] .rel.ARM.exidx    REL             00000000 01378c 000008 08   I  0   3  4
  [ 5] .eh_frame         PROGBITS        0001a8c8 012988 000004 00   A  0   0  4
  [ 6] .init_array       INIT_ARRAY      0001a8dc 01298c 000078 04  WA  0   0  4
  [ 7] .rel.init_array   REL             00000000 013794 0000f0 08   I  0   6  4
  [ 8] .fini_array       FINI_ARRAY      0001a954 012a04 000004 04  WA  0   0  4
  [ 9] .rel.fini_array   REL             00000000 013884 000008 08   I  0   8  4
  [10] .data.rel.ro      PROGBITS        0001a958 012a08 0000e8 00  WA  0   0  4
  [11] .rel.data.rel.ro  REL             00000000 01388c 000178 08   I  0  10  4
  [12] .got              PROGBITS        0001aa40 012af0 000950 04  WA  0   0  4
  [13] .data             PROGBITS        0001b390 013440 00030c 00  WA  0   0  4
  [14] .rel.data         REL             00000000 013a04 0001e0 08   I  0  13  4
  [15] .bss              NOBITS          0001b69c 01374c 0009d0 00  WA  0   0  4
  [16] .comment          PROGBITS        00000000 01374c 000011 01  MS  0   0  1
  [17] .ARM.attributes   ARM_ATTRIBUTES  00000000 01375d 00002c 00      0   0  1
  [18] .noinit           PROGBITS        0001c06c 013789 000000 00   W  0   0  1
  [19] .shstrtab         STRTAB          00000000 013be4 000098 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  D (mbind), y (purecode), p (processor specific)
```
- Full strip (invalid for NOMMU targets)
```
readelf -S _build/armv7m4-stm32l4x6/prog.stripped/psh 
There are 15 section headers, starting at offset 0x13810:

Section Headers:
  [Nr] Name              Type            Addr     Off    Size   ES Flg Lk Inf Al
  [ 0]                   NULL            00000000 000000 000000 00      0   0  0
  [ 1] .text             PROGBITS        00008000 0000c0 00fe28 00  AX  0   0  8
  [ 2] .rodata           PROGBITS        00017e28 00fee8 002a95 00   A  0   0  4
  [ 3] .ARM.exidx        ARM_EXIDX       0001a8c0 012980 000008 00  AL  1   0  4
  [ 4] .eh_frame         PROGBITS        0001a8c8 012988 000004 00   A  0   0  4
  [ 5] .init_array       INIT_ARRAY      0001a8dc 01298c 000078 04  WA  0   0  4
  [ 6] .fini_array       FINI_ARRAY      0001a954 012a04 000004 04  WA  0   0  4
  [ 7] .data.rel.ro      PROGBITS        0001a958 012a08 0000e8 00  WA  0   0  4
  [ 8] .got              PROGBITS        0001aa40 012af0 000950 04  WA  0   0  4
  [ 9] .data             PROGBITS        0001b390 013440 00030c 00  WA  0   0  4
  [10] .bss              NOBITS          0001b69c 01374c 0009d0 00  WA  0   0  4
  [11] .comment          PROGBITS        00000000 01374c 000011 01  MS  0   0  1
  [12] .ARM.attributes   ARM_ATTRIBUTES  00000000 01375d 00002c 00      0   0  1
  [13] .noinit           PROGBITS        0001c06c 013789 000000 00   W  0   0  1
  [14] .shstrtab         STRTAB          00000000 013789 000084 00      0   0  1
Key to Flags:
  W (write), A (alloc), X (execute), M (merge), S (strings), I (info),
  L (link order), O (extra OS processing required), G (group), T (TLS),
  C (compressed), x (unknown), o (OS specific), E (exclude),
  D (mbind), y (purecode), p (processor specific)
```

So script removes following sections:
.rel.text
.symtab
.strtab

And current stripped binaries is different from fully stripped binary by sections:
.rel.ARM.exidx
.rel.init_array
.rel.fini_array
.rel.data
.rel.data.rel.ro

Almost all of this sections is needed for data relocations in kernel so it seems that solution provide currently the best possible result comparing to MMU platform

The only thing is I'm not sure about .rel.ARM.exidx which contain R_ARM_PREL31 relocation if that section could be also removed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (armv7m4-stm32l4x6).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/107
https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/39
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/106
https://github.com/phoenix-rtos/phoenix-rtos-doc/pull/114
- [x] I will merge this PR by myself when appropriate.
