### PR TITLE
allow building projects without git repository

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,8 +111,13 @@ mkdir -p "$PREFIX_PROG" "$PREFIX_PROG_STRIPPED"
 if declare -f "b_prepare" > /dev/null; then
 	b_prepare
 fi
-echo " $(git rev-parse HEAD) $(basename "$(git rev-parse --show-toplevel)") ($(git describe --always --dirty))" > "${PREFIX_BUILD}/git-version"
-git submodule status --recursive >> "${PREFIX_BUILD}/git-version"
+
+if command -v git > /dev/null && [ -a ".git" ]; then
+    echo " $(git rev-parse HEAD) $(basename "$(git rev-parse --show-toplevel)") ($(git describe --always --dirty))" > "${PREFIX_BUILD}/git-version"
+    git submodule status --recursive >> "${PREFIX_BUILD}/git-version"
+else
+    echo "not available" > "${PREFIX_BUILD}/git-version"
+fi
 
 #
 # Preparing filesystem


### PR DESCRIPTION
JIRA: ISM-46

When build directory is is not a git repository write "not available" into git-version and continue build.

Previously running build inside non-git project directory resulted in aborted build with multiple git commands errors or writing git information from git repository that was in project directory parent.

## Motivation and Context
This allows using phoenix-rtos-build for ad-hoc projects that are automatically created using scripts. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
