### PR TITLE
armv7m: Pass default mfloat-abi=soft

### DIFF
--- a/Makefile.armv7m
+++ b/Makefile.armv7m
@@ -21,9 +21,9 @@ CFLAGS += -fdata-sections -ffunction-sections
 ifeq ($(TARGET_FAMILY), armv7m7)
   CFLAGS += -mcpu=cortex-m7 -mfloat-abi=hard -mfpu=fpv5-d16
 else ifeq ($(TARGET_FAMILY), armv7m4)
-  CFLAGS += -mcpu=cortex-m4 -fstack-usage
+  CFLAGS += -mcpu=cortex-m4 -mfloat-abi=soft -fstack-usage
 else ifeq ($(TARGET_FAMILY), armv7m3)
-  CFLAGS += -mcpu=cortex-m3 -fstack-usage
+  CFLAGS += -mcpu=cortex-m3 -mfloat-abi=soft -fstack-usage
 endif
 
 ifeq ($(TARGET_SUBFAMILY), stm32l152xd)


### PR DESCRIPTION
JIRA: ISC-185

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Add mfloat-abi flag set to compiler default
Compiler default can be checked by arm-phoenix-gcc -Q --help=target
-mfloat-abi=                          soft
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
static analyzer clang-tidy is noisy about missing mfloat-abi definition. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4x6 build.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
