### PR TITLE
toolchain: Enable deterministic archive

### DIFF
--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -88,7 +88,7 @@ build_binutils() {
     pushd "${BINUTILS}/build" > /dev/null
 
     ../configure --target="${TARGET}" --prefix="${TOOLCHAIN_PREFIX}" \
-                 --with-sysroot="${SYSROOT}" --enable-lto
+                 --with-sysroot="${SYSROOT}" --enable-lto --enable-deterministic-archives
     make
 
     log "installing binutils"


### PR DESCRIPTION
Used by ar, ranlib, objcopy, strip when operating on .a file. When enabled, all timestamps, GID, UID is setted to zero for checksum determinism.

It's not strictly required for reproducable binary but allows to have deterministic .a files - it should be the same on every machine when compiled from same source code.

JIRA: ISC-222

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
In this change, binutils flag was added to improve building artifacts reprodicibility
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While looking at binary reproducibilty I found that .a files on different machines differs with timestamps in header. Then I found that flag and I found it's useful in terms of build reprodicibility. 

It's not critical, because those timestapmts are not included in binary but I found' that's good mechanism.

Results of md5sum on libphoenix.a from  two consecutive builds with old and new toolchain (phoenix-rtos-project 818fe8960dcfc71d49f3596486dee1e9ee240d40)

Old:
```
d4c6d6efae5af14cd301424b5d56b17b  _build/armv7m4-stm32l4x6-nucleo/lib/libphoenix.a
c37a4ff523933cc22b5d2c4b9e703d08  _build/armv7m4-stm32l4x6-nucleo/lib/libphoenix.a
```

New:
```
7facdffc11c821341b67436ec908a552  _build/armv7m4-stm32l4x6-nucleo/lib/libphoenix.a
7facdffc11c821341b67436ec908a552  _build/armv7m4-stm32l4x6-nucleo/lib/libphoenix.a
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: stm32l4x6.

Would be great if test could be run on toolchain with that flag

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
