### PR TITLE
build: add execute of bear tool on top of build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,6 +103,22 @@ for i in "${ARGS[@]}"; do
 	esac;
 done
 
+if ! command -v /bin/bear &> /dev/null; then
+	echo "'bear' executable not found. Compilation database will not be built"
+elif [ -z "${DO_NOT_EXEC_BEAR+x}" ]; then
+	b_log "Running bear on top of build script"
+
+	OUTPUT_FILE=_build/"$TARGET"/compile_commands.json
+
+	# Exec build one more time with bear on top
+	if [[ "$(bear --version 2>&1)" == "bear 2."* ]]; then
+		DO_NOT_EXEC_BEAR=y exec bear -o "$OUTPUT_FILE" --append "$0" "${ARGS[@]}"
+	else
+		# versions 3.*.*
+		DO_NOT_EXEC_BEAR=y exec bear --output "$OUTPUT_FILE" --append -- "$0" "${ARGS[@]}"
+	fi
+fi
+
 #
 # Clean if requested
 #


### PR DESCRIPTION
If `bear` executable is available, execute it on top of build to generate compilation database. The database is stored in _build/$TARGET as compile_commands.json.

JIRA: CI-127

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
