### PR TITLE
Do not change optimization for DEBUG builds

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -33,10 +33,7 @@ ifneq ($(filter-out -O%,$(OLVL)),)
   $(error OLVL set but does not provide optimisation flags)
 endif
 
-# for debug build always use -Og optimisation
-ifeq ($(DEBUG), 1)
-  OLVL := -Og
-else
+ifneq ($(DEBUG), 1)
   CFLAGS += -DNDEBUG
   CXXFLAGS += -DNDEBUG
 endif


### PR DESCRIPTION
DONE: RTOS-442

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Make -Og optional on DEBUG, not mandatory

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To allow testing builds with debugs/asserts enabled without destroying performance and code size

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (imx6ull).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
