### PR TITLE
Add option to install unstripped binaries into rootfs and enable it for host-generic-pc

### DIFF
--- a/Makefile.host
+++ b/Makefile.host
@@ -32,4 +32,8 @@ CFLAGS += -fsanitize=address,undefined
 LDFLAGS += -fsanitize=address,undefined
 endif
 
+# install unstripped binaries in rootfs
+# (cruicial for tests binaries with debug info for meaningful sanitizers info)
+ROOTFS_INSTALL_UNSTRIPPED := y
+
 CXXFLAGS += $(filter-out -Wstrict-prototypes, $(CFLAGS))

--- a/makes/binary.mk
+++ b/makes/binary.mk
@@ -14,6 +14,9 @@
 # - LOCAL_LDFLAGS - additional LDFLAGS for current component linking
 # - LOCAL_INSTALL_PATH - custom rootfs dir for the binary to be installed (if not provided - DEFAULT_INSTALL_PATH)
 
+# Global variables (not reset by this script):
+# - ROOTFS_INSTALL_UNSTRIPPED - if non-empty - install binaries into rootfs from PREFIX_PROG (instead of _STRIPPED)
+
 
 # directory with current Makefile - relative to the repository root
 # filter-out all Makefiles outside of TOPDIR
@@ -89,8 +92,15 @@ $(NAME)-clean:
 # install into the root filesystem
 LOCAL_INSTALL_PATH := $(or $(LOCAL_INSTALL_PATH),$(DEFAULT_INSTALL_PATH))
 
+# add option to install unstripped binaries
+ifeq ($(ROOTFS_INSTALL_UNSTRIPPED),)
+  ROOTFS_BIN_SRC := $(PREFIX_PROG_STRIPPED)$(NAME)
+else
+  ROOTFS_BIN_SRC := $(PREFIX_PROG)$(NAME)
+endif
+
 $(NAME)-install: $(NAME) $(PREFIX_ROOTFS)$(LOCAL_INSTALL_PATH)/$(NAME)
-$(PREFIX_ROOTFS)$(LOCAL_INSTALL_PATH)/$(NAME): $(PREFIX_PROG_STRIPPED)$(NAME)
+$(PREFIX_ROOTFS)$(LOCAL_INSTALL_PATH)/$(NAME): $(ROOTFS_BIN_SRC)
 	$(INSTALL_FS)
 
 # necessary for NAME variable to be correctly set in recepies


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- host-generic-pc: install unstripped binaries into rootfs by default
  Needed to provide meaningful backtraces on sanitizer errors.
- makes: add option to install unstripped binaries into rootfs
  Needed for host-generic-pc to provide meaningful backtraces on sanitizer
  errors.

## Motivation and Context
  Fixes: phoenix-rtos/phoenix-rtos-project#797

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `host-generic-pc`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
