### PR TITLE
make: add PROJECT_PATH to CFLAGS includes only if non-empty

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -92,8 +92,10 @@ ifneq ($(KERNEL), 1)
 endif
 
 # make PROJECT_PATH the first search dir to allow project customizations/monkey-patching
-CFLAGS := -I$(PROJECT_PATH) $(CFLAGS)
-CXXFLAGS := -I$(PROJECT_PATH) $(CXXFLAGS)
+ifneq ($(PROJECT_PATH),)
+  CFLAGS := -I$(PROJECT_PATH) $(CFLAGS)
+  CXXFLAGS := -I$(PROJECT_PATH) $(CXXFLAGS)
+endif
 
 # add multilib directory to library search path
 SYSROOT := $(shell $(CC) $(CFLAGS) -print-sysroot)


### PR DESCRIPTION
## Description

Fixes building toolchain (multilib libphoenix via direct make).

## Motivation and Context

JIRA: CI-334

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
