### PR TITLE
make: Add passing WATCHDOG as define

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -36,6 +36,9 @@ endif
 
 ifneq ($(DEBUG), 1)
   CPPFLAGS += -DNDEBUG
+  WATCHDOG ?= 1
+else
+  WATCHDOG ?= 0
 endif
 
 TOPDIR := $(CURDIR)
@@ -132,6 +135,10 @@ CXXFLAGS += $(OLVL)
 # Distribute the __TARGET and __CPU defines
 CPPFLAGS += -D__TARGET_$(call uppercase,$(TARGET_FAMILY))
 CPPFLAGS += -D__CPU_$(call uppercase,$(TARGET_SUBFAMILY))
+
+ifneq ($(WATCHDOG), 0)
+  CPPFLAGS += -DWATCHDOG
+endif
 
 #
 # Generic rules


### PR DESCRIPTION
JIRA: DEND-32 DTR-408

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This change enable possibility to pass WATCHDOG to kernel/plo build

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
While we want to deprecate BOARD_CONFIG env, we need to find a way to pass watchdog setting to kernel/plo. Decided to do so via env which is defaultly enabled. Need to be disabled directly when not wanted.
Also it enables WATCHDOG on armv7a7-imx6ull

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->
Application to handle watchdog needed if watchdog wasn't enabled before. Alternatively - disable watchdog explicitly

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv7m4-stm32l4x6-nucleo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-project/pull/847
https://github.com/phoenix-rtos/plo/pull/293
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/453
https://github.com/phoenix-rtos/phoenix-rtos-build/pull/163
- [x] I will merge this PR by myself when appropriate.
