### PR TITLE
toolchain: abort if environment is not valid

### DIFF
--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -18,21 +18,24 @@ declare -A TOOLCHAN_TO_PHOENIX_TARGETS=(
     [sparc-phoenix]="sparcv8leon3-gr716 sparcv8leon3-gr712rc"
 )
 
-if [ -z "$1" ] || [ -z "${TOOLCHAN_TO_PHOENIX_TARGETS[$1]}" ]; then
+TARGET="$1"
+BUILD_ROOT="$2"
+
+if [ -z "$TARGET" ] || [ -z "${TOOLCHAN_TO_PHOENIX_TARGETS[$TARGET]}" ]; then
     echo "Missing or invalid target provided! Abort."
     echo "officially supported targets:"
     printf "%s\n" "${!TOOLCHAN_TO_PHOENIX_TARGETS[@]}"
     exit 1
 fi
 
-PHOENIX_TARGETS="${TOOLCHAN_TO_PHOENIX_TARGETS[$1]}"
+PHOENIX_TARGETS="${TOOLCHAN_TO_PHOENIX_TARGETS[$TARGET]}"
 
-if [ -z "$2" ]; then
+if [ -z "$BUILD_ROOT" ]; then
     echo "No toolchain install path provided! Abort."
     exit 1
 fi
 
-if [ "${2:0:1}" != "/" ]; then
+if [ "${BUILD_ROOT:0:1}" != "/" ]; then
     echo "Path must not be relative."
     exit 1
 fi
@@ -51,6 +54,12 @@ if [[ -v CC || -v CFLAGS || -v LIBS || -v CPPFLAGS || -v CXX || -v CXXFLAGS || -
     exit 1
 fi
 
+if command -v "${TARGET}-gcc" > /dev/null; then
+    echo "Command \"${TARGET}-gcc\" found in PATH. Abort."
+    echo "Make sure to to remove existing toolchain from PATH"
+    exit 1
+fi
+
 # old legacy versions of the compiler:
 #BINUTILS=binutils-2.28
 #GCC=gcc-7.1.0
@@ -58,8 +67,6 @@ fi
 BINUTILS=binutils-2.34
 GCC=gcc-9.5.0
 
-TARGET="$1"
-BUILD_ROOT="$2"
 TOOLCHAIN_PREFIX="${BUILD_ROOT}/${TARGET}"
 SYSROOT="${TOOLCHAIN_PREFIX}/${TARGET}"
 MAKEFLAGS="-j9 -s"

--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -42,6 +42,15 @@ if [ ! -f "$SCRIPT_DIR/../../phoenix-rtos-kernel/Makefile" ] || [ ! -f "$SCRIPT_
     exit 1
 fi
 
+# Those env variables override command line options passed to configure scripts
+# This check was added due to libstdc++ configure using host compiler instead of cross compiler
+# TODO: check if all stages are affected. If not then consider using unset in those stages
+if [[ -v CC || -v CFLAGS || -v LIBS || -v CPPFLAGS || -v CXX || -v CXXFLAGS || -v CPP || -v CXXCPP || -v CXXFILT ]]; then
+    echo "Environment contains variables that should not be set. Abort."
+    echo "Make sure to unset CC CFLAGS LIBS CPPFLAGS CXX CXXFLAGS CPP CXXCPP CXXFILT"
+    exit 1
+fi
+
 # old legacy versions of the compiler:
 #BINUTILS=binutils-2.28
 #GCC=gcc-7.1.0


### PR DESCRIPTION
JIRA: CI-377

## Description
Configure scripts treat some environment variables as overrides for command line options. This aborts build if those variables are set.

I decided to abort instead of doing unset so that we can easily see in what environments/platforms this could be an issue.  As I written in comments proper solution might be to unset those variables only for cross stages.

## Motivation and Context
I was building toolchain with CC variable set to host compiler. It was building without issues. After libstdc++ was added c++ builds were failing due to missing include files.

```
                  from /build/source/_user/hellocpp/main.cpp:16:
 /build/source/_build/ia32-generic-qemu/sysroot/include/c++/cwctype:50:10: fatal error: wctype.h: No such file or directory
    50 | #include <wctype.h>
       |          ^~~~~~~~~~
```
After some investigation I found that `./configure` script was ignoring cross compiler passed in command line options as CC variable has higher priority.

Configure script used host compiler / includes to check what is available and created `config.h` include file that did not match what was available in target sysroot.