### PR TITLE
sparcv8leon3: use FPU on GR712RC

### DIFF
--- a/target/sparcv8leon3.mk
+++ b/target/sparcv8leon3.mk
@@ -33,9 +33,12 @@ ifeq ($(TARGET_SUBFAMILY), gr716)
   endif
 
 else ifeq ($(TARGET_SUBFAMILY), gr712rc)
+  ifeq ($(KERNEL), 1)
+    CFLAGS += -msoft-float
+  endif
   STRIP := $(CROSS)strip
   VADDR_KERNEL_INIT := 0xc0000000
-  CFLAGS += -msoft-float -mfix-gr712rc -DLEON3_TN_0018_FIX
+  CFLAGS += -mfix-gr712rc -DLEON3_TN_0018_FIX
   LDFLAGS += -Wl,-z,max-page-size=0x1000
 
 else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Remove `-msoft-float` flag on GR712RC userspace code, to enable generating FP instructions
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
