### PR TITLE
Enable optional libposixsrv on STM32L4

### DIFF
--- a/build-core-armv7m4-stm32l4x6.sh
+++ b/build-core-armv7m4-stm32l4x6.sh
@@ -21,6 +21,12 @@ if [ "$LIBPHOENIX_DEVEL_MODE" = "y" ]; then
 	make -C "libphoenix" all install
 fi
 
+b_log "Building libtty"
+make -C "phoenix-rtos-devices" libtty libtty-install
+
+b_log "Building libposixsrv"
+make -C "phoenix-rtos-posixsrv" libposixsrv libposixsrv-install
+
 b_log "Building phoenix-rtos-corelibs"
 make -C "phoenix-rtos-corelibs" all install
 


### PR DESCRIPTION
### Work in progress

Change adds possibility to use optional `libposixsrv` in `stm32l4-multi` driver.

#### Note: build of `libtty` before `libposixsrv` is required because of `posixsrv` dependency on `libtty`.

JIRA: RTOS-641

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `stm32l4a6-nucleo`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
