### PR TITLE
add setup and test execution script

### DIFF
--- a/scripts/run_project_tests.py
+++ b/scripts/run_project_tests.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+
+"""
+A script to run unity and pytest tests in a host environment for Phoenix-RTOS.
+
+Example of config file:
+
+    campaign_name:
+        unity:
+            - binary1 args
+            - binary2
+        pytest:
+            - path1 args
+            - path2
+"""
+
+import subprocess
+import argparse
+import sys
+import os
+from typing import Dict, List
+
+import yaml
+from colorama import Fore, init
+
+
+class TestSetupError(Exception):
+    pass
+
+
+def run_test(test_cmd: List[str], test_name: str, stream: bool) -> int:
+    """Executes a single test command"""
+    print(f"{Fore.MAGENTA}Running {test_name}: ", flush=True, end="\n" if stream else "")
+
+    if stream:
+        result = subprocess.run(test_cmd, text=True)
+        print(f"{Fore.MAGENTA}Running {test_name}: ", flush=True, end="")
+    else:
+        result = subprocess.run(test_cmd, capture_output=True, text=True)
+
+    if result.returncode != 0:
+        print(f"{Fore.RED}FAIL")
+        if not stream:
+            if result.stdout:
+                print(f"{Fore.YELLOW}STDOUT:")
+                print(result.stdout, end='')
+            if result.stderr:
+                print(f"{Fore.RED}STDERR:")
+                print(result.stderr, end='')
+    else:
+        print(f"{Fore.GREEN}OK")
+
+    return result.returncode
+
+
+def parse_args() -> argparse.Namespace:
+    """Parses script arguments"""
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("-C", "--campaign", default="ci", help="Set campaign to run (default: %(default)s)")
+    parser.add_argument("-c", "--config", default=".tests_config.yaml", help="Set path to config (default: %(default)s)")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose mode")
+    parser.add_argument("-S", "--stream", action="store_true", help="Stream the output of test on stdout")
+    return parser.parse_args()
+
+
+def get_target() -> str:
+    target = os.environ.get("TARGET")
+    if not target:
+        raise TestSetupError("TARGET environment variable is not set.")
+    return target
+
+
+def read_yaml_config(yaml_path: str) -> dict:
+    """Loads test configurations from YAML files"""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as file:
+            config = yaml.safe_load(file)
+    except Exception as e:
+        raise TestSetupError(f"Error while reading config file: {e}") from e
+
+    return config
+
+
+def run_tests(config: dict, campaign:str, target: str, verbose: bool, stream: bool) -> Dict[str, int]:
+    """Executes the specified tests"""
+    exit_codes = {}
+    test_types = ["unity", "pytest"]
+
+    if campaign not in config:
+        raise ValueError(f"Campaign '{campaign}' not found in the config file.")
+
+    for test_type, tests in config[campaign].items():
+
+        if test_type not in test_types:
+            raise TestSetupError(f"Unexpected test type '{test_type}' in campaign '{campaign}'. Expected {test_types}.")
+
+        print(f"{Fore.YELLOW}- Start {test_type} tests -")
+
+        for test in tests:
+            if test_type == "pytest":
+                test_cmd = ["pytest"] + test.split()
+                if not verbose:
+                    test_cmd.append("--tb=no")
+                if verbose or stream:
+                    test_cmd.append("-v")
+            if test_type == "unity":
+                test_cmd = [f"./_build/{target}/prog/{test}"]
+
+            exit_codes[test] = run_test(test_cmd, test, stream)
+
+            if exit_codes[test] != 0:
+                print(f"{Fore.RED}{test} exited with: {exit_codes[test]}")
+
+    return exit_codes
+
+
+def main():
+    init(autoreset=True)
+
+    try:
+        args = parse_args()
+        target = get_target()
+        config = read_yaml_config(args.config)
+
+        completed_tests = run_tests(config, args.campaign, target, args.verbose, args.stream)
+        if any(code != 0 for code in completed_tests.values()):
+            if args.verbose:
+                print(f"{Fore.YELLOW}Completed tests and their exit codes: {completed_tests}")
+            return 1
+
+    except TestSetupError as e:
+        print(f"{Fore.RED}{str(e)}")
+        return 1
+    except Exception as e:
+        print(f"{Fore.RED}Unexpected Error: {str(e)}")
+        return 1
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
JIRA: CI-411

A script to run unity and pytest tests in a host environment for Phoenix-RTOS.
### Example of usage:
    TARGET=host-generic-target ./phoenix-rtos-build/scripts/run_project_tests.py
    Options:
    - C - Set campaign to run
    - c - Set path to config
    - v - Enable verbose mode
    - S - Stream the output of test on stdout

### Example of config file:
    campaign_name:
        unity:
            - binary1 args
            - binary2
        pytest:
            - path1 args
            - path2

### Need to know:
    Need vm.map_rnd_bits set to 28
    You can use: sudo sysctl vm.mmap_rnd_bits=28
    due to the issue reported here: https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1032

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
