### PR TITLE
toolchain: fix building toolchain

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -142,6 +142,11 @@ ifneq ($(WATCHDOG), 0)
   CPPFLAGS += -DWATCHDOG
 endif
 
+# check if the final build environment is sane
+ifeq ($(NOCHECKENV),)
+  include $(MAKES_PATH)/check-env.mk
+endif
+
 #
 # Generic rules
 #

--- a/makes/check-env.mk
+++ b/makes/check-env.mk
@@ -1,0 +1,26 @@
+# Makefile for Phoenix-RTOS 3
+#
+# Copyright 2024 Phoenix Systems
+#
+
+# check if the final build environment is sane
+# when building components directly (omitting build.sh entry point) you might want to disable these checks
+
+# Verify variables used for kernel compilation
+ifndef HAVE_MMU
+  ifneq ($(TARGET_FAMILY), host)
+    $(error "HAVE_MMU is not set")
+  endif
+endif
+
+ifeq ($(HAVE_MMU), y)
+  ifneq ($(KERNEL_PHADDR),)
+    $(error "KERNEL_PHADDR is set for MMU target, please check project configuration")
+  endif
+endif
+
+ifeq ($(HAVE_MMU), n)
+  ifeq ($(KERNEL_PHADDR),)
+    $(error "KERNEL_PHADDR is not set for NOMMU target, please check project configuration")
+  endif
+endif

--- a/makes/include-target.mk
+++ b/makes/include-target.mk
@@ -79,22 +79,3 @@ ifeq (,$(filter $(TARGETS),$(TARGET_FAMILY)-$(TARGET_SUBFAMILY)))
 endif
 
 include $(MAKES_PATH)/../target/$(TARGET_SUFF).mk
-
-# Verify variables
-ifndef HAVE_MMU
-  ifneq ($(TARGET_FAMILY), host)
-    $(error "HAVE_MMU is not set")
-  endif
-endif
-
-ifeq ($(HAVE_MMU), y)
-  ifneq ($(KERNEL_PHADDR),)
-    $(error "KERNEL_PHADDR is set for MMU target, please check project configuration")
-  endif
-endif
-
-ifeq ($(HAVE_MMU), n)
-  ifeq ($(KERNEL_PHADDR),)
-    $(error "KERNEL_PHADDR is not set for NOMMU target, please check project configuration")
-  endif
-endif

--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -174,13 +174,14 @@ build_libc() {
     mkdir -p "${SYSROOT}/usr/include"
     ln -snf usr/include "${SYSROOT}/include"
 
+    # NOCHECKENV: don't check if build env is sane - we're building only necessary components by hand
     for phx_target in $PHOENIX_TARGETS; do
         log "[$phx_target] installing kernel headers"
-        make -C "$SCRIPT_DIR/../../phoenix-rtos-kernel" TARGET="$phx_target" install-headers
+        make -C "$SCRIPT_DIR/../../phoenix-rtos-kernel" NOCHECKENV=1 TARGET="$phx_target" install-headers
 
         # FIXME: libphoenix should be installed for all supported multilib target variants
         log "[$phx_target] installing libphoenix"
-        make -C "$SCRIPT_DIR/../../libphoenix" TARGET="$phx_target" clean install
+        make -C "$SCRIPT_DIR/../../libphoenix" NOCHECKENV=1 TARGET="$phx_target" clean install
     done
 
     PATH="$OLDPATH"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Cherry-picking changes from master to release branch:
- toolchain: skip checking if build env is sane
- makes: make build env sanity checks optional
  Needed for building toolchain (uses install-headers directly without build.sh
  entrypoint).


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
