### PR TITLE
toolchain: fix arm cortex subvariant check

### DIFF
--- a/toolchain/gcc-9.5.0-05-arm-pic_crtstuff.patch
+++ b/toolchain/gcc-9.5.0-05-arm-pic_crtstuff.patch
@@ -1,11 +1,16 @@
 diff -Naur gcc-9.3.0-orig/libgcc/config/arm/t-phoenix gcc-9.3.0/libgcc/config/arm/t-phoenix
 --- gcc-9.3.0-orig/libgcc/config/arm/t-phoenix	1970-01-01 01:00:00.000000000 +0100
 +++ gcc-9.3.0/libgcc/config/arm/t-phoenix	2021-08-23 13:40:28.290478307 +0200
-@@ -0,0 +1,7 @@
+@@ -0,0 +1,12 @@
 +# PhoenixRTOS uses relocatable ELFs on NOMMU platforms
-+# if this is ARM Cortex-M subvariant -> build libgcc/crtstuff with PIC
-+# ALSO: ensure data is not intertwined with .text, otherwise running XIP programs would fail
-+ifneq ($(findstring -m,$(filter -march=arm%, $(CC)))),)
++# if this is ARM Cortex-M/R subvariant -> build libgcc/crtstuff with PIC
++# ALSO: ensure data is not interwined with .text, otherwise running XIP programs would fail
++
++PS_MARCH := $(patsubst -march=%,%,$(filter -march=arm%, $(CC)))
++PS_IS_CORTEX_M := $(findstring -m,$(PS_MARCH))
++PS_IS_CORTEX_R := $(findstring -r,$(PS_MARCH))
++
++ifneq ($(PS_IS_CORTEX_M)$(PS_IS_CORTEX_R),)
 +  CRTSTUFF_T_CFLAGS = $(PICFLAG) -mno-pic-data-is-text-relative
 +  INTERNAL_CFLAGS += $(PICFLAG) -mno-pic-data-is-text-relative
 +endif


### PR DESCRIPTION
## Description

Cortex-A was incorrectly detected as Cortex-M resulting in building libgcc/crtstuff with compile options dedicated for NOMMU. These binaries were not runnable as for MMU targets we're stripping reloc sections during build.

## Motivation and Context

JIRA: CI-453

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
