### PR TITLE
update build system to export STRIP variable

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -161,6 +161,9 @@ export-cxxflags:
 export-ldflags:
 	@echo $(EXPORT_LDFLAGS)
 
+export-strip:
+	@echo $(STRIP)
+
 help:
 	$(info DEFAULT_COMPONENTS := $(DEFAULT_COMPONENTS))
 	$(info ALL_COMPONENTS := $(ALL_COMPONENTS))
@@ -172,6 +175,7 @@ help:
 	@echo "  export-cflags   outputs contents of CFLAGS variable"
 	@echo "  export-cxxflags outputs contents of CXXFLAGS variable"
 	@echo "  export-ldflags  outputs contents of LDFLAGS variable"
+	@echo "  export-strip    outputs contents of STRIP variable"
 	@echo
 	@echo "available per-target make targets:"
 	@echo "  <target>          build <target>"

--- a/build.sh
+++ b/build.sh
@@ -74,10 +74,11 @@ export TARGET TARGET_FAMILY TARGET_SUBFAMILY TARGET_PROJECT PROJECT_PATH PREFIX_
 
 # export flags for ports - call make only after all necessary env variables are already set
 EXPORT_CFLAGS="$(make -f phoenix-rtos-build/Makefile.common export-cflags)"
-# Convert ldflags to format recognizable by gcc, for example -q -> -Wl,-q
 EXPORT_LDFLAGS="$(make -f phoenix-rtos-build/Makefile.common export-ldflags)"
+# export STRIP path & args for stripping binaries
+EXPORT_STRIP="$(make -f phoenix-rtos-build/Makefile.common export-strip)"
 
-export EXPORT_CFLAGS EXPORT_LDFLAGS
+export EXPORT_CFLAGS EXPORT_LDFLAGS EXPORT_STRIP
 
 
 #


### PR DESCRIPTION
Export the STRIP variable to enable building ports on both MMU and NOMMU targets.

JIRA: RTOS-840

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `ia32-generic-qemu`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
