### PR TITLE
build.subr: Make b_install accept multiple source files

### DIFF
--- a/build.subr
+++ b/build.subr
@@ -4,23 +4,28 @@
 #
 # Common functions
 #
-# Copyright 2018, 2019 Phoenix Systems
+# Copyright 2018, 2019, 2024 Phoenix Systems
 # Author: Kaja Swat, Aleksander Kaminski, Pawel Pisarczyk
 #
 
+# b_install(src ..., dstdir)
 b_install() {
-	bin="$1"
-	dir="$2"
+	local filelist=("${@:1:$#-1}")
+	local dstdir="${@: -1}"
 
-	if ! [ -f "$bin" ]; then
-		echo -e "\033[0;31m$bin binary does not exist \033[0m"
-		exit 1
-	fi
+	local absdir="${PREFIX_FS}/root/$dstdir"
 
-	echo -e "\033[0;35mInstalling $(basename "$bin") into $dir \033[0m"
+	mkdir -p "$absdir"
 
-	mkdir -p "$PREFIX_FS/root/$dir"
-	install -m 755 "$bin" "$PREFIX_FS/root/$dir"
+	for file in "${filelist[@]}"; do
+		if ! [ -f "$file" ]; then
+			echo -e "\033[0;31mFile $file does not exist \033[0m"
+			exit 1
+		fi
+
+		echo -e "\033[0;35mInstalling $(basename "$file") into $dstdir \033[0m"
+		install -m 755 "$file" "$absdir"
+	done
 }
 
 


### PR DESCRIPTION
`b_install` function will accept any number of source files and one destination directory, which mimics system tool `install`. This makes it possible to use glob expansions when invoking the function.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
