### PR TITLE
build: add noexecstack flag

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -125,6 +125,7 @@ EXPORT_LDFLAGS := $(LDFLAGS)
 # add our coding-style related options
 CFLAGS += -Wall -Wstrict-prototypes -fno-common
 CXXFLAGS += -Wall
+LDFLAGS += -z noexecstack
 
 # always produce binaries with debug information
 CFLAGS += -ggdb3


### PR DESCRIPTION
Newer linker version(>-2.39) issues a warning if stack is executable. Setting -z stack-size without -z noexecstack can cause this issue. On Phoenix stack is currently never executable.

JIRA: RTOS-909

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work https://github.com/phoenix-rtos/phoenix-rtos-project/pull/1160
- [ ] I will merge this PR by myself when appropriate.
