### PR TITLE
!toolchain/ld: change arm emul

### DIFF
--- a/toolchain/binutils-2.34-03-arm-phoenix-emul-fix.patch
+++ b/toolchain/binutils-2.34-03-arm-phoenix-emul-fix.patch
@@ -1,0 +1,48 @@
+diff --git a/ld/configure.tgt b/ld/configure.tgt
+index f937f78b876..989b3753eb3 100644
+--- a/ld/configure.tgt
++++ b/ld/configure.tgt
+@@ -198,7 +198,10 @@ arm-*-netbsd*)	targ_emul=armelf_nbsd;
+ 			;;
+ arm-*-nto*)		targ_emul=armnto
+ 			;;
+-arm-*-phoenix*)		targ_emul=armelf
++arm-*-phoenix*)
++			targ_emul=armelf_phoenix
++			targ_extra_emuls="armelf"
++			targ_extra_libpath=$targ_extra_emuls
+ 			;;
+ armeb-*-elf | armeb-*-eabi*)
+ 			targ_emul=armelfb
+diff --git a/ld/emulparams/armelf_phoenix.sh b/ld/emulparams/armelf_phoenix.sh
+index 63c35a8290b..ceb1edc42e6 100644
+--- a/ld/emulparams/armelf_phoenix.sh
++++ b/ld/emulparams/armelf_phoenix.sh
+@@ -1,24 +1,8 @@
+-ARCH=arm
+-SCRIPT_NAME=elf
+-OUTPUT_FORMAT="elf32-littlearm"
+-BIG_OUTPUT_FORMAT="elf32-bigarm"
+-LITTLE_OUTPUT_FORMAT="elf32-littlearm"
++source_sh ${srcdir}/emulparams/armelf.sh
+ MAXPAGESIZE="CONSTANT (MAXPAGESIZE)"
+ COMMONPAGESIZE="CONSTANT (COMMONPAGESIZE)"
+-TEMPLATE_NAME=elf
+-EXTRA_EM_FILE=armelf
+-GENERATE_SHLIB_SCRIPT=yes
+-GENERATE_PIE_SCRIPT=yes
+-
+-DATA_START_SYMBOLS='PROVIDE (__data_start = .);';
+-OTHER_TEXT_SECTIONS='*(.glue_7t) *(.glue_7) *(.vfp11_veneer) *(.v4_bx)'
+-OTHER_BSS_SYMBOLS="${CREATE_SHLIB+PROVIDE (}__bss_start__ = .${CREATE_SHLIB+)};"
+-OTHER_BSS_END_SYMBOLS="${CREATE_SHLIB+PROVIDE (}_bss_end__ = .${CREATE_SHLIB+)}; ${CREATE_SHLIB+PROVIDE (}__bss_end__ = .${CREATE_SHLIB+)};"
+-OTHER_END_SYMBOLS="${CREATE_SHLIB+PROVIDE (}__end__ = .${CREATE_SHLIB+)};"
+-OTHER_SECTIONS='.note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }'
+-
+ TEXT_START_ADDR=0x00001000
+ TARGET2_TYPE=got-rel
+ 
+-# ARM does not support .s* sections.
+-NO_SMALL_DATA=yes
++unset STACK_ADDR
++unset EMBEDDED


### PR DESCRIPTION
Previously we defined armelf_phoenix emulation that wasn't used. This patch fixes the configuration to use it.
Additionally support in armelf_phoenix emulation for shared libs is added.

JIRA: RTOS-911

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [x] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work 
https://github.com/phoenix-rtos/phoenix-rtos-kernel/pull/586
- [ ] I will merge this PR by myself when appropriate.
