### PR TITLE
image builder: allow passing commands directly by using `%` prefix

### DIFF
--- a/scripts/image_builder.py
+++ b/scripts/image_builder.py
@@ -133,6 +133,10 @@ class PloCmdFactory:
 
         # TODO: add compile-time checks for scripts validity (eg. memory regions cross-check)?
 
+        # allow passing commands directly without parsing them by using `%` prefix
+        if cmd.startswith("%"):
+            return PloCmdGeneric(cmd[1:].strip())
+
         # generic PLO command - treated for now as string
         return PloCmdGeneric(cmd)
 


### PR DESCRIPTION
## Description

With this change you can hand-craft commands which normally would be parsed by `image_builder.py`, eg:

`%app flash0 -x psh;-i;/etc/rc.psh ddr ddr;nonexistent` (will not generate corresponding `alias`, will not add `psh` to the target image automatically)

This usage is discouraged and should be used only in testing and some extremely hackish use cases.


<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes shortly -->

## Motivation and Context

JIRA: CI-494


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: `NIL`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
