### PR TITLE
Makefile.common: fix ld version parsing

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -87,8 +87,10 @@ endif
 
 # Do not warn about RWX segments.
 # binutils >= 2.39 required
-LD_VERSION_MINOR := $(shell $(LD) $(LDFLAGS_PREFIX)--version 2> /dev/null | grep -Eo "[0-9][0-9]$$")
-ifeq ($(shell expr $(LD_VERSION_MINOR) ">=" 39), 1)
+LD_VERSION_MINOR := $(shell $(LD) $(LDFLAGS_PREFIX)--version 2> /dev/null | grep -Eo "\b2\.[0-9]*" | cut -d . -f 2)
+ifeq ($(LD_VERSION_MINOR),)
+$(error Can't parse LD version!)
+else ifeq ($(shell expr $(LD_VERSION_MINOR) ">=" 39), 1)
 LDFLAGS += $(LDFLAGS_PREFIX)--no-warn-rwx-segments
 endif
 


### PR DESCRIPTION
Fix ld version parsing not working for version format `<Major>.<Minor>.<Patch>`
Add explicit error when version cannot be parsed.

JIRA: RTOS-959

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
