### PR TITLE
toolchain: Allow build toolchain from any working dir

### DIFF
--- a/toolchain/build-toolchain.sh
+++ b/toolchain/build-toolchain.sh
@@ -72,7 +72,7 @@ export MAKEFLAGS
 
 mkdir -p "${TOOLCHAIN_PREFIX}"
 mkdir -p "${BUILD_DIR}"
-cp ./*.patch "${BUILD_DIR}"
+cp "$SCRIPT_DIR"/*.patch "${BUILD_DIR}"
 cd "${BUILD_DIR}"
 
 download() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
Use absolute path to toolchain patches, relatively to script dir

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Our build toolchain script is almost ready to build toolchain without entering phoenix-rtos-build/toolchain/ directory prior to execute build-toolchain.sh script. It makes our buildsystem cleaner. After this change, toolchain building instruction can be simplified:

```
./phoenix-rtos-build/toolchain/build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix
(...)
```
instead of:
```
 (cd phoenix-rtos-build/toolchain/ && ./build-toolchain.sh i386-pc-phoenix ~/toolchains/i386-pc-phoenix)
(...)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: building toolchain for sparc from phoenix-rtos-project main dir

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
