### PR TITLE
aarch64: add -mno-outline-atomics compilation flag

### DIFF
--- a/target/aarch64.mk
+++ b/target/aarch64.mk
@@ -15,7 +15,9 @@ OLVL ?= -O2
 
 cpu := cortex-$(subst aarch64,,$(TARGET_FAMILY))
 
-CFLAGS += -mcpu=$(cpu) -mtune=$(cpu) -fomit-frame-pointer -mstrict-align
+# -mno-outline-atomics disables compiler feature that relies on runtime detection of LSE instruction set extension.
+# We currently don't support this feature and may not need it, as target CPU is known at compile time.
+CFLAGS += -mcpu=$(cpu) -mtune=$(cpu) -fomit-frame-pointer -mstrict-align -mno-outline-atomics
 CXXFLAGS := $(CFLAGS)
 
 AR := $(CROSS)ar


### PR DESCRIPTION
This fixes system hang on Zynq Ultrascale+ after update to GCC 14.2.

## Description
The newer GCC version implements atomic operations using a function that may use LSE extension instructions. It decided whether to use these instructions using a flag in memory (`__aarch64_have_lse_atomics`). However, because we do not use glibc, the flag was never initialized. Additionally, because in kernel the `.bss` segment is not initialized to 0, system would hang non-deterministically on real hardware (on QEMU uninitialized memory reads as 0, so it would never hang).

With `-mno-outline-atomics` flag, GCC only uses LSE instructions if they are mandatory for the architecture given in `-mcpu` flag. LSE is mandatory starting from Arm v8.1.

Because we do not use glibc, the "outline atomics" feature would require additional changes to work. The changes would have to be in kernel, libphoenix and plo. Disabling the feature seems like a better choice because Phoenix-RTOS applications are compiled for a specific platform, so the target instruction set (and extensions) are known at compile time. If Phoenix-RTOS is ever ported to an Arm v8.0 system with LSE and enabling support would be beneficial, we can do it per-target by adding `+lse` to the `-mcpu` flag.

## Motivation and Context
Closes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1297

DONE: RTOS-1050

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
