### PR TITLE
scripts/image_builder: early return from parsing PLO script if 'if' clause is false

### DIFF
--- a/scripts/image_builder.py
+++ b/scripts/image_builder.py
@@ -508,12 +508,13 @@ def parse_plo_script(nvm: List[FlashMemory], script_name: str) -> PloScript:
                     cmd_rendered = render_val(cmd, **tpl_context)
                     cmddef = PloCmdFactory.build(cmd_rendered)
                 else:
-                    # render all values
-                    args = {k: render_val(v, **tpl_context) for k, v in cmd.items()}
-                    enabled = args.pop('if', True)
+                    enabled = render_val(cmd.get('if', True), **tpl_context)
                     if not str2bool(enabled):
-                        logging.debug("PLO command disabled (if: '%s'): %s", enabled, str(args))
+                        logging.debug("PLO command disabled: %s", str(cmd))
                         continue
+
+                    # render all values
+                    args = {k: render_val(v, **tpl_context) for k, v in cmd.items() if k != 'if'}
 
                     if 'str' in args:
                         # command still as string, just conditional


### PR DESCRIPTION
The PLO script was parsed first and then checked for 'if' clauses, which did not give the script's user the possibility of e.g. checking if variable is defined and using it in the command if that is the case. Checking before rendering gives the user more flexibility.

Example: imxrt117x `user.plo.yaml` script could wants to check if env.LWIP_EXEC_CONFIG is defined and use it in the command if that's the case.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
