### PR TITLE
scripts: add stm32n6 secure boot

### DIFF
--- a/scripts/stm32n6_log_util.py
+++ b/scripts/stm32n6_log_util.py
@@ -1,0 +1,97 @@
+#
+# Log utility for STM32N6 scripts
+#
+# Copyright 2023 Phoenix Systems
+# Author: Krzysztof Radzewicz
+#
+
+import sys, math
+
+DEBUG_LOG_ENABLED = False
+
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def error(mess: str) -> None:
+    info_log(mess, bcolors.FAIL)
+    exit(1)
+
+
+def hex2bytes(hexstr: str) -> bytes:
+    hexstr = "".join(hexstr.split())
+    return bytes([int(hexstr[i] + hexstr[i + 1], 16) for i, x in enumerate(hexstr) if i % 2 == 0])
+
+
+def bytes2hex(data: bytes) -> str:
+    return "".join([f"{b:02x}" for b in data])
+
+
+def b2chr(i: int) -> str:
+    c = chr(i)
+    if c.isalnum():
+        return c
+    else:
+        return '.'
+
+
+def log_bytes(data: bytes):
+    for i, b in enumerate(data):
+        if i % 8 == 0:
+            print(f"\n{bcolors.HEADER}0x{i:08X}{bcolors.ENDC}", end=" ")
+        print(f"{b:02x} ", end="")
+        
+
+def debug_log(mess: str, marker: bcolors = None) -> None:
+    if DEBUG_LOG_ENABLED:
+        if marker == None:
+            marker = marker_end = ""
+        else:
+            marker_end = bcolors.ENDC
+        print(f"{marker}{mess}{marker_end}")
+
+
+def info_log(mess: str, marker: bcolors = None, end="\n"):
+    if marker == None:
+        marker = marker_end = ""
+    else:
+        marker_end = bcolors.ENDC
+    print(f"{marker}{mess}{marker_end}", end=end)
+
+
+def log_progress_init(width: int):
+    info_log(f"[{" " * width}]", bcolors.OKCYAN, "")
+    print("\x1b[1G", end="")
+    sys.stdout.flush()
+
+
+def log_progress(width: int, progress: float):
+    count: int = math.ceil(width * progress)
+    print("\x1b[2G", end="")
+    info_log(f"{"=" * count}", bcolors.OKGREEN, "")
+    sys.stdout.flush()
+
+
+def log_progress_end(width: int):
+    print("\x1b[1G", end="")
+    mess = "Loading sucessful!"
+    info_log(f"{mess}{(width + 2 - len(mess)) * " "}", bcolors.OKCYAN)
+
+
+def check_bin_file(file_path: str):
+    try:
+        f = open(file_path, 'rb')
+        f.close()
+    except FileNotFoundError:
+        error(f"ERROR: {file_path} file not found")
+    except Exception as e:
+        error(f"ERROR: {e} error while opening {file_path}")
+

--- a/scripts/stm32n6_requirements.txt
+++ b/scripts/stm32n6_requirements.txt
@@ -1,0 +1,9 @@
+#
+# requirements.txt for stm32n6 scripts
+#
+# Copyright 2025 Phoenix Systems
+# Author: Krzysztof Radzewicz
+#
+
+pycryptodome==3.23.0
+pyserial==3.5

--- a/scripts/stm32n6_sign_fsbl.py
+++ b/scripts/stm32n6_sign_fsbl.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+#
+# Sign FSBL image for STM32N6 secure boot
+#
+# Copyright 2025 Phoenix Systems
+# Author: Krzysztof Radzewicz
+#
+
+import  argparse, struct, os, subprocess
+from typing import BinaryIO
+from stm32n6_log_util import *
+import hashlib
+import base64
+from Crypto.Hash import CMAC
+from Crypto.Cipher import AES
+
+
+FSBL_POS = 1024         # Payload starts at 1024
+END_ZEROS = 16          # Payload padded with >=16 zeros so that the full image size is a multiple of 16
+BEG_ZEROS = 448         # Payload padded with 448 zeros at the beginning so that first real byte is at pos 1024
+ 
+HEADER_TOTL_SIZE = 576
+HEADER_BASE_SIZE = 160
+HEADER_AUTH_SIZE = 116  # Modified later
+HEADER_ENCR_SIZE = 32
+HEADER_PADD_SIZE = -1   # Modified later
+
+
+#### PARSE ARGUMENTS
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sign an STM32N6 FSBL image")
+    parser.add_argument("-i", "--image", required=True, help="Specify the stripped image file to sign")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    parser.add_argument("-o", "--output", required=True, help="Path to output header file")
+    parser.add_argument("-la", "--load-address", required=True, help="Specify a load address of image")
+    parser.add_argument("-iver", "--image-version", default="0", help="Specify image version")
+    parser.add_argument("-prvk", "--private-key", required=True, help="Path to unencrypted EC private (.pem) key used to sign image")
+    parser.add_argument("-pubk-id", "--public-key-index", required=True, help="Specify the index of the public key used to verify signature (0-7)")
+    parser.add_argument("-pubk", "--public-key", nargs="+", required=True, help="Path to 1-8 EC public keys (.pem) to be accepted for verification")
+    parser.add_argument("-enc-dc", "--encryption-dc", nargs=1, help="Specify derivation constant used to derive encryption key")
+    parser.add_argument("-enc-key", "--encryption-key", nargs=1, help="Path to OEM secret file used to derive encryption key")
+    args = parser.parse_args()
+
+    global DEBUG_LOG_ENABLED, HEADER_AUTH_SIZE, HEADER_PADD_SIZE, END_ZEROS
+    DEBUG_LOG_ENABLED = args.verbose
+
+    check_bin_file(args.image)
+
+    # VALIDATE KEYS 
+    check_bin_file(args.private_key)
+    if (l := len(args.public_key)) < 1 or l > 8:
+        error(f"Argument error: provide 1 to 8 public keys")
+    for pubk in args.public_key:
+        check_bin_file(pubk)
+    args.public_key_index = int(args.public_key_index)
+    if args.public_key_index < 0 or args.public_key_index >= l:
+        error(f"Argument error: public key index needs to be in range [0, num keys - 1 ({l - 1})]") 
+    validate_keys(args.private_key, args.public_key, args.public_key_index)
+
+    args.load_address = struct.pack("<I", int(args.load_address, 16))
+    args.image_version = struct.pack("<I", int(args.image_version))
+    args.algorithm = struct.pack("<I", 1)
+
+    # ENCRYPTION
+    args.ext_flags = 0x80000001
+    if args.encryption_dc == None and args.encryption_key == None:
+        args.encrypt = False
+    elif args.encryption_dc != None and args.encryption_key != None:
+        args.encryption_key = args.encryption_key[0]
+        args.encryption_dc = validate_dc(args.encryption_dc[0])
+        check_bin_file(args.encryption_key)
+        args.encrypt = True
+        args.ext_flags = 0x80000003
+    else:
+        error("Argument error: for encryption, both OEM secret and derivation constant need to be specified")
+    
+    HEADER_AUTH_SIZE += l * 32
+    HEADER_PADD_SIZE = HEADER_TOTL_SIZE - HEADER_BASE_SIZE - HEADER_AUTH_SIZE
+    if args.encrypt:
+        HEADER_PADD_SIZE -= HEADER_ENCR_SIZE
+
+    img_size = os.path.getsize(args.image) + BEG_ZEROS + END_ZEROS
+    END_ZEROS += (16 - (img_size % 16))
+
+    return args
+
+
+# Verify that key files are properly encoded and that the indexed public key is compatible with the private key
+def validate_keys(private_key: str, public_keys: list[str], public_key_index: int):
+    # TODO: Support other key encodings and verify their correctness
+    # For now only checking if private key corresponds to public key
+
+    subprocess.run(["openssl", "ec", "-in", private_key, "-pubout", "-out", ".sign_pubkey.pem"], capture_output=True)
+    with open(".sign_pubkey.pem", "rb") as tmp:
+        with open(public_keys[public_key_index], "rb") as pbkf:
+            assert tmp.read() == pbkf.read()
+    os.remove(".sign_pubkey.pem")
+
+
+def validate_dc(encryption_dc: str) -> bytes:
+    intdc = int(encryption_dc, 0)
+    if intdc > 0xFFFFFFFF or intdc < 0:
+        error("Argument error: provide a derivation constant as an unsigned 4 byte integer")
+    return intdc.to_bytes(4, byteorder="little")
+
+
+
+#### FILE OPERATIONS
+def cpy_content(input: BinaryIO, output: BinaryIO) -> None:
+    input.seek(0)
+    while True:
+        chunk = input.read(256)
+        if not chunk:
+            break
+        output.write(chunk)
+
+
+# Gets the entry point address from the second value in the interrupt vector table
+def get_entry_point(raw_image: BinaryIO) -> bytes:
+    raw_image.seek(4)
+    return raw_image.read(4)
+
+
+def get_image_checksum(payload: bytes) -> bytes:
+    chksum: int = 0x00
+    for byte in payload:
+        chksum = (chksum + byte) & 0xFFFFFFFFF
+    return struct.pack("<I", chksum)
+
+
+# For now assuming .pem format
+def get_pubkey_bytes(key_path: str) -> bytes:
+    with open(key_path, "rb") as fk:
+        b64data = b"".join(list(map(lambda line: line.replace(b"\n", b""), fk.readlines()[1:-1])))
+        # Skipping 27 bytes of metadata
+        return base64.standard_b64decode(b64data)[27:]
+
+
+# Removes ANS.1/DER metadata from ecdsa signature
+def strip_ecdsa_der(signature_path: str) -> bytes:
+    with open(signature_path, "rb") as f:
+        f.seek(3)
+        r_len = int.from_bytes(f.read(1))
+        r_bytes = f.read(r_len)
+        if r_bytes[0] == 0x00:
+            r_bytes = r_bytes[1:]
+        f.read(1) # skips 0x02 (INT) byte
+        s_len = int.from_bytes(f.read(1))
+        s_bytes = f.read(s_len)
+        if s_bytes[0] == 0x00:
+            s_bytes = s_bytes[1:]
+
+        return r_bytes + s_bytes + bytes(32)
+    
+
+#### CRYPTOGRAPHY
+def aes_cmac_pfr_128(var_key: bytes, M: bytes):
+    if len(var_key) == 16:
+        key = var_key
+    else:
+        key = CMAC.new(bytes(16), ciphermod=AES)\
+                  .update(var_key)\
+                  .digest()
+    return CMAC.new(key, ciphermod=AES)\
+               .update(M)\
+               .digest()
+
+
+def encrypt_stm_payload(payload: bytes, iv: bytes, enc_key_file: str, derivation_const: bytes) -> bytes:
+    with open(enc_key_file, "rb") as f:
+        edmk = f.read()
+
+    # Magic numbers that are set by ST
+    M = bytearray(32)
+    M[3] = 0x01
+    M[0x04:0x17] = b"BL2 encryption key."
+    M[0x1F] = 0x80
+    M[0x18:0x1C] = derivation_const
+
+    fsbl_key = aes_cmac_pfr_128(edmk, M)
+    cipher = AES.new(fsbl_key, AES.MODE_CBC, iv=iv)
+    return cipher.encrypt(payload)
+
+
+#### HEADER FUNCTIONS
+def header_base(sig_file: BinaryIO, img_size: int, entry_point: bytes, img_checksum: bytes, args: argparse.Namespace) -> None:
+    sig_file.seek(0)
+    sig_file.write(b'\x53\x54\x4d\x32')                                     # Magic number
+    sig_file.write(bytes(96))                                               # ECDSA Signature (zero bytes)
+    sig_file.write(img_checksum)                                            # Image Checksum
+    sig_file.write(b'\x00\x03\x02\x00')                                     # Header version
+    sig_file.write(struct.pack("<I", img_size))                             # Image size
+    sig_file.write(entry_point)                                             # Entry point
+    sig_file.write(bytes(4))                                                # Reserved1
+    sig_file.write(args.load_address)                                       # Load address
+    sig_file.write(bytes(4))                                                # Reserved2
+    sig_file.write(args.image_version)                                      # Image version
+    sig_file.write(struct.pack("<I", args.ext_flags))                       # Extension flags
+    sig_file.write(struct.pack("<I", HEADER_TOTL_SIZE - HEADER_BASE_SIZE))  # Post header length
+    sig_file.write(struct.pack("<I", 16))                                   # Binary type
+    sig_file.write(bytes(8))                                                # PAD
+    sig_file.write(bytes(4))                                                # Nonsec payload length 
+    sig_file.write(bytes(4))                                                # Nonsec payload hash
+
+
+def header_auth(sig_file: BinaryIO, args: argparse.Namespace):
+    sig_file.write(b'\x53\x54\x00\x02')                      # Magic number
+    sig_file.write(struct.pack("<I", HEADER_AUTH_SIZE))      # Extension header length
+    sig_file.write(struct.pack("<I", args.public_key_index)) # Public key index (which one to use)
+    sig_file.write(struct.pack("<I", len(args.public_key)))  # Number of public keys in table
+    sig_file.write(args.algorithm)                           # ECDSA Algorithm num (1-4)
+
+    pbk_path = args.public_key[args.public_key_index]
+    sig_file.write(get_pubkey_bytes(pbk_path) + bytes(32))   # Verification public key (padding for ECDSA 256)
+
+    # Public key hashes
+    for pubkey_path in args.public_key:
+        sig_file.write(hashlib.sha256(args.algorithm + get_pubkey_bytes(pubkey_path)).digest())
+
+
+def header_encr(sig_file: BinaryIO, plain_hash: bytes, args: argparse.Namespace):
+    sig_file.write(b"\x53\x54\x00\x01")                      # Magic number
+    sig_file.write(struct.pack("<I", HEADER_ENCR_SIZE))      # Exntension header length
+    sig_file.write(struct.pack("<I", 128))                   # Key size
+    sig_file.write(args.encryption_dc)                       # Derivation constant
+    sig_file.write(plain_hash)                               # 128 msb bits of of plain payload SHA256 hash
+
+
+def header_padd(sig_file: BinaryIO, padd_header_size: int):
+    sig_file.write(b'\x53\x54\xff\xff')                      # Magic number
+    sig_file.write(struct.pack("<I", padd_header_size))      # Extension header length
+    sig_file.write(os.urandom(padd_header_size - 8))         # Padding bytes
+
+
+def add_payload(sig_file: BinaryIO, payload: bytes) -> None:
+    sig_file.seek(HEADER_TOTL_SIZE)
+    sig_file.write(payload)
+
+
+def add_signature(sig_file: BinaryIO, payload: bytes, args: argparse.Namespace) -> None:
+    sigblock = bytearray()
+    sig_file.flush()
+    sig_file.seek(104)
+    sigblock.extend(sig_file.read(48))
+    sig_file.seek(HEADER_BASE_SIZE)
+    sigblock.extend(sig_file.read(HEADER_TOTL_SIZE - HEADER_BASE_SIZE))
+    sigblock.extend(payload)
+
+    hash_file: str = ".tmp_hash_file"
+    signature_file: str = ".sign_ecdsa_der"
+    with open(hash_file, "wb") as hf:
+        hf.write(hashlib.sha256(sigblock).digest())
+    
+    subprocess.run(["openssl", "pkeyutl", "-sign", "-inkey", args.private_key, "-in", hash_file, "-out", signature_file], \
+                   check=True, capture_output=True, text=True)
+    sig_file.seek(4)
+    sig_file.write(strip_ecdsa_der(signature_file))
+    os.remove(hash_file)
+    os.remove(signature_file)
+
+
+def main() -> None:
+    args = parse_args()
+    sig_file = open(args.output, "w+b")
+    img_file = open(args.image, "rb")
+
+    payload = bytes(BEG_ZEROS) + img_file.read() + bytes(END_ZEROS)
+    if args.encrypt:
+        plain_hash = hashlib.sha256(payload).digest()[:16]
+        payload = encrypt_stm_payload(payload, plain_hash, args.encryption_key, args.encryption_dc)
+    image_size = len(payload)
+    entry_point = get_entry_point(img_file)
+    check_sum = get_image_checksum(payload)
+
+    # At first sign without signature
+    header_base(sig_file, image_size, entry_point, check_sum, args)
+    header_auth(sig_file, args)
+    if args.encrypt:
+        header_encr(sig_file, plain_hash, args)
+    header_padd(sig_file, HEADER_PADD_SIZE)
+
+    add_payload(sig_file, payload)
+
+    add_signature(sig_file, payload, args)
+
+    img_file.close()
+    sig_file.close()
+
+    info_log("Signing successfull!", bcolors.OKGREEN)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/stm32n6_uart_boot.py
+++ b/scripts/stm32n6_uart_boot.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+#
+# Boot STM32N6 via UART
+#
+# Copyright 2025 Phoenix Systems
+# Author: Krzysztof Radzewicz
+#
+
+import serial, traceback, argparse, struct, os
+from stm32n6_log_util import *
+
+
+SERIAL_DEVICE = ""
+
+
+#### CODES
+ACK = bytes([0x79]) 
+ACK_ACK = bytes([0x79, 0x79])
+NACK = bytes(0x1F)
+BEGIN = bytes([0x7F])
+
+CMD_GET = bytes([0x00, 0xFF])
+CMD_GETVER = bytes([0x01, 0xFE])
+CMD_GET_ID = bytes([0x02, 0xFD])
+CMD_GET_PHASE = bytes([0x03, 0xFC])
+CMD_WRITE_MEM = bytes([0x31, 0xCE])
+CMD_READ_PART = bytes([0x12, 0xED])
+CMD_START = bytes([0x21, 0xDE])
+
+
+class AckException(Exception):
+    def __init__(self, function: str):
+        super().__init__(f"{function}: missing ACK response")
+
+
+# SCRIPT ARGUMENTS:
+# uart_boot.py -i <image-path> [-v -h] [-d --device <serial port device>]
+# -i --image: file path to plo image to load
+# -v --verbose: enable verbose debug messages
+# -d --device: a serial port device path ex. /dev/ttyACM0
+def parse_args():
+    parser = argparse.ArgumentParser(description="Perform Serial Boot via UART on STM32N6")
+    parser.add_argument("-i", "--image", required=True, help="Specify the image file to load via Boot ROM")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Enable verbose output")
+    parser.add_argument("-d", "--device", default="/dev/ttyACM0", help="Select serial port device")
+    args = parser.parse_args()
+    global DEBUG_LOG_ENABLED
+    DEBUG_LOG_ENABLED = args.verbose
+    try:
+        f = open(args.image, 'rb')
+        f.close()
+    except FileNotFoundError:
+        info_log(f"ERROR: {args.image} file not found", bcolors.WARNING)
+        exit(1)
+    except Exception as e:
+        info_log(f"ERROR: unknown error while opening {args.image}", bcolors.WARNING)
+        exit(1)
+    
+    return args
+
+
+TO_STRING = {int.from_bytes(ACK): "ACK", int.from_bytes(NACK): "NACK"}
+def b2str(byte_arr: bytes) -> str:
+    return ", ".join([TO_STRING.get(byte, f"{hex(byte)}") for byte in byte_arr])
+
+
+def validate_cmdset(avail_cmds: bytes) -> int:
+    for c in bytes([0x0, 0x1, 0x2, 0x3, 0x12, 0x12, 0x21, 0x31]):
+        if c not in avail_cmds:
+            raise Exception(f"get: Command with code {c} is not available.")
+
+
+def calc_checksum(byte_arr: bytes) -> bytes:
+    res = 0x00
+    for byte in byte_arr:
+        res ^= byte
+    return bytes([res])
+
+
+def sp_write(sp: serial.Serial, b: bytes):
+    sp.write(b)
+
+
+#### BOOTROM COMMANDS
+def cmd_get(sp: serial.Serial, verbose: bool = True) -> None: 
+    debug_log("GET:")
+    sp_write(sp, CMD_GET)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("get")
+
+    response = sp.read_until(ACK)
+    if bytes([response[-1]]) != ACK:
+        raise AckException("get")
+
+    num_commands = response[0] + 1
+    ver = f"{(response[1] & 0xF0) >> 4}.{response[1] & 0xF}"
+    avail_cmds = response[2:]
+
+    if verbose:
+        debug_log(f"Num of commands: {num_commands}")
+        info_log(f"Protocol version: {ver}", bcolors.OKCYAN)
+        validate_cmdset(avail_cmds)
+        debug_log(f"Commands validated!")
+
+
+def cmd_getver(sp: serial.Serial) -> None:
+    debug_log("GET VERSION:")
+    sp_write(sp, CMD_GETVER)
+    debug_log("write 0x01 0xFE")
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("getver")
+    
+    response = sp.read_until(ACK)
+    if bytes([response[-1]]) != ACK:
+        raise AckException("getver")
+
+    ver = f"{response[0] & 0x2}.{response[0] & 0x1}"
+    debug_log(f"Protocol version: {ver}")
+
+
+def cmd_getid(sp: serial.Serial, verbose: bool = True) -> None:
+    debug_log("GET ID:")
+    sp_write(sp, CMD_GET_ID)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("getid")
+    
+    response = sp.read_until(ACK)
+    if bytes([response[-1]]) != ACK:
+        raise AckException("gettid")
+    
+    pid = (response[0] << 4) | response[1]
+    if verbose:
+        info_log(f"Device ID: {pid}", bcolors.OKCYAN)
+
+
+def cmd_getphase(sp: serial.Serial) -> tuple[int, bytes]:
+    debug_log("GET PHASE:")
+    sp_write(sp, CMD_GET_PHASE)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("getphase")
+    
+    response = sp.read_until(ACK)
+    if bytes([response[-1]]) != ACK:
+        raise AckException("getphase")
+    
+
+    phase = response[1]
+    address = response[5:1:-1]
+    return phase, address
+
+
+# Download command
+def cmd_writemem(sp: serial.Serial, packet_num: int, data: bytes) -> int:
+    debug_log("WRITE MEMORY:")
+    sp_write(sp, CMD_WRITE_MEM)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("writemem")
+    
+    if packet_num >= 0xF2:
+        raise Exception("writemem: tried to write OTP")
+    
+    packetid = struct.pack(">I", packet_num)
+    sp_write(sp, packetid + calc_checksum(packetid))
+    
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException(f"writemem, packet: {packet_num}")
+    
+    if len(data) > 256:
+        raise Exception("writemem: packet too long")
+    
+    size = len(data) - 1
+    buf = bytes([size]) + data
+    sp_write(sp, buf + calc_checksum(buf))
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException(f"writemem, packet: {packet_num}")
+
+
+def download_image(sp: serial.Serial, image_path: str):
+    info_log(f"Loading {image_path} image...", bcolors.OKCYAN)
+    log_progress_init(50)
+    imgsize = os.path.getsize(image_path) / 256
+    last_progress = 0
+    imgf = open(image_path, "rb")
+    counter = 0
+    while True:
+        part = imgf.read(256)
+        if not part:
+            break
+        cmd_writemem(sp, counter, part)
+        counter += 1
+
+        if counter / imgsize > last_progress + 0.3:
+            last_progress = counter / imgsize
+            log_progress(50, last_progress)
+
+    imgf.close()
+    log_progress_end(50)
+
+
+def cmd_start(sp: serial.Serial, start_addr: int):
+    debug_log("START:")
+    sp_write(sp, CMD_START)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("start")
+
+    jmp_addr = struct.pack(">I", start_addr)
+    sp_write(sp, jmp_addr + calc_checksum(jmp_addr))
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("readpart")
+
+
+# Reads the certificate of the device
+def cmd_readpart(sp: serial.Serial, offset: int, rsize: int) -> bytes:
+    debug_log("READ PARTITION:")
+    sp_write(sp, CMD_READ_PART)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException("readpart")
+    
+    buf = struct.pack(">B", 0xF3) + struct.pack(">I", offset)
+    print(f"buf1: {buf}")
+    sp_write(sp, buf + calc_checksum(buf))
+    
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException(f"readpart, off: {offset}")
+    
+    size_bytes = struct.pack(">B", min(255, rsize - 1))
+    buf = size_bytes + bytes([int.from_bytes(size_bytes) ^ 0xFF])
+    print(f"buf2: {buf}")
+    sp_write(sp, buf)
+
+    response = sp.read(size=1)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK:
+        raise AckException(f"readpart, offset: {offset}")
+    
+    return sp.read(rsize)
+    
+
+def handshake(sp: serial.Serial) -> None:
+    sp_write(sp, BEGIN)
+    debug_log("write BEGIN")
+    response = sp.read(size=2)
+    debug_log(f"recv {b2str(response)}")
+    if response != ACK_ACK and response != ACK:
+        raise AckException("handshake")
+
+
+def main() -> None:
+    args = parse_args()
+
+    sp = serial.Serial()
+    sp.port = args.device
+    sp.baudrate = 115200
+    sp.parity = serial.PARITY_EVEN
+    sp.stopbits = serial.STOPBITS_ONE
+    sp.bytesize = serial.EIGHTBITS
+    sp.timeout = 2
+
+    try:
+        sp.open()
+        info_log("===== UART BOOT =====", bcolors.HEADER)
+        handshake(sp)
+        cmd_get(sp)
+        cmd_getid(sp)
+        download_image(sp, args.image)
+        cmd_start(sp, 0xFFFFFFFF)
+        info_log("=====================", bcolors.HEADER)
+
+    except Exception as err:
+        info_log(f"ERROR: {err}", bcolors.WARNING)
+        trace_str = traceback.format_exc()
+        info_log(trace_str, bcolors.FAIL)
+
+    finally:
+        sp.close()
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
STM32N6 secureboot scripts
JIRA: RTOS-1084

## Description
Add .py scripts for signing and encrypting a fsbl image and load it via uart serial interface on stm32n6 platform.
Image signing involves calculating ecdsa signature with openssl and encrypting the image with aes 128 cbc mode.
Encryption key is derived via ST magic numbers + user provided derivation constant.
User provides elliptic curve keys for the signature.

## Motivation and Context
Part of [RTOS-1084](https://youtrack.phoenix-rtos.com/issue/RTOS-1084) Support SecureBoot on STM32N6

## Types of changes
Add working scripts for secureboot signing and booting, no key generation yet

## How Has This Been Tested?
Signed/encrypted plo image and loaded it via uart
