### PR TITLE
riscv64.mk: don't check RISCV_ISA_STRING when NOCHECKENV=1

### DIFF
--- a/target/riscv64.mk
+++ b/target/riscv64.mk
@@ -15,11 +15,15 @@ CXX := $(CROSS)g++
 
 OLVL ?= -O2
 
-ifeq ($(RISCV_ISA_STRING),)
-  $(error RISCV_ISA_STRING is not set.)
+# Don't check when building toolchain - FIXME: libphoenix in toolchain should be built as multilib
+ifneq ($(NOCHECKENV),1)
+  ifeq ($(RISCV_ISA_STRING),)
+    $(error RISCV_ISA_STRING is not set. TARGET=$(TARGET))
+  endif
+  CFLAGS += -march=$(RISCV_ISA_STRING)
 endif
 
-CFLAGS += -fomit-frame-pointer -mcmodel=medany -march=$(RISCV_ISA_STRING)
+CFLAGS += -fomit-frame-pointer -mcmodel=medany
 
 CXXFLAGS := $(CFLAGS)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->
This is a workaround for libphoenix being built with the toolchain, where RISCV_ISA_STRING is not set. The build will use the default risc-v configuration until proper multilib support is added.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/phoenix-rtos/phoenix-rtos-project/issues/1360

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
