### PR TITLE
port_manager: pass `str_to_bool` to jinja env as global `bool` function

### DIFF
--- a/port_manager/build_layer.py
+++ b/port_manager/build_layer.py
@@ -43,6 +43,8 @@ PORT_MGMT_DIR = Path(__file__).parent
 # borrowed from phoenix-rtos-build/scripts/image_builder.py
 def str_to_bool(v: str | bool) -> bool:
     """False is denoted by empty string or any literal sensible false values"""
+    if not v:
+        return False
     if isinstance(v, bool):
         return v
     return v.lower() not in ("", "no", "false", "n", "0")
@@ -89,7 +91,7 @@ def find_ports(ports_dir: str) -> Generator[tuple[dict[str, str], Path]]:
         yield (dct, port_def)
 
 
-PortsToBuildDict = dict[str, str | dict[str, str] | list[dict[str, str]]]
+PortsToBuildDict = dict[str, bool | str | dict[str, str] | list[dict[str, str]]]
 
 
 def get_ports_to_build(
@@ -97,16 +99,17 @@ def get_ports_to_build(
 ) -> PortsToBuildDict | None:
     """
     Reads port.yaml files from colon-separated ports_yamls. Files are first
-    rendered as jinja2 templates with OS environment, allowing for env-dependent
-    configs like:
+    rendered as jinja2 templates with OS environment and a `bool` function for
+    converting bool-like string environment variables to boolean, allowing
+    for env-dependent configs like:
     ```
-    tests: '{{ env.BUILD_TESTS | default(false) }}' # tests built iff BUILD_TESTS is true
+    tests: {{ bool(env.BUILD_TESTS) }} # tests built iff BUILD_TESTS is true
     ports:
     - name: foo
-      use: {{ ["flag"] if env.FOO_FLAG }}
+      use: {{ ["flag"] if bool(env.USE_FOO_FLAG) }}
       tests: True
     - name: bar
-      if: '{{ env.BUILD_BAR | default(false) }}' # bar built iff BUILD_BAR is true
+      if: {{ bool(env.BUILD_BAR) }} # bar built iff BUILD_BAR is true
     ```
     This is a behaviour somewhat similar to plo yaml scripts.
     """
@@ -118,6 +121,7 @@ def get_ports_to_build(
             continue
         with open(ports_yaml, encoding="utf-8") as f:
             template = jinja2.Template(f.read())
+            template.globals["bool"] = str_to_bool
             dct = yaml.safe_load(template.render(env=os.environ))
             if dct:
                 nonempty_ports_yamls.append(ports_yaml)

--- a/port_manager/port_manager.py
+++ b/port_manager/port_manager.py
@@ -224,7 +224,7 @@ class PortManager:
                 )[0]
 
             if isinstance(port, dict):
-                if not build_layer.str_to_bool(port.get("if", True)):
+                if not port.get("if", True):
                     cands.pop(str(cand), None)
                     continue
 

--- a/port_manager/port_manager.py
+++ b/port_manager/port_manager.py
@@ -11,7 +11,7 @@
 #
 
 from __future__ import annotations
-from typing import TypeVar
+from typing import Any, TypeVar
 from collections.abc import Callable
 from collections.abc import Sequence, Generator
 
@@ -61,6 +61,14 @@ def parse_namever(namever: str) -> Constraint:
     if len(elems) != 2:
         raise ValueError(f"bad name-ver - expected NAME-VERSION, got '{namever}'")
     return (elems[0], PhxVersion(elems[1]))
+
+
+def require_bool(dct: dict[str, Any], key: str, default: bool) -> bool:
+    val = dct.get(key, default)
+    if not isinstance(val, bool):
+        logger.error(f"'{key}' should be bool but got {val} ({val.__class__})")
+        sys.exit(1)
+    return val
 
 
 class PortManager:
@@ -167,26 +175,32 @@ class PortManager:
             result = resolver.resolve([ureq])
             self.mapping[namever] = result.mapping
 
-    def read_ports_yaml(self) -> tuple[list[InstallableCandidate], list[str]]:
+    def read_ports_yaml(self) -> tuple[list[InstallableCandidate], set[str]]:
         ports_dict = self.get_ports_to_build(self.args.ports_yamls)
 
         if not ports_dict:
             logger.warning("No port requirements for target. Nothing to do")
             sys.exit(0)
 
-        enable_tests = ports_dict.get("tests", True)
+        enable_tests = require_bool(ports_dict, "tests", True)
 
         if "ports" not in ports_dict or not ports_dict["ports"]:
             logger.error("no ports to install? (`ports:` not present in ports.yaml)")
             sys.exit(1)
 
+        if not isinstance(ports_dict["ports"], list):
+            logger.error("'ports' should be a list")
+            sys.exit(1)
+
         cands: dict[str, InstallableCandidate] = dict()
 
-        disabled_ports = ports_dict.get("disabled-ports", [])
-        if not isinstance(disabled_ports, list) or any(not isinstance(i, str) for i in disabled_ports):
+        disabled_ports_list = ports_dict.get("disabled-ports", [])
+        if not isinstance(disabled_ports_list, list) or any(
+            not isinstance(i, str) for i in disabled_ports_list
+        ):
             logger.error("'disabled-ports' should be a list of port names (strings)")
             sys.exit(1)
-        disabled_ports = set(disabled_ports)
+        disabled_ports = set(disabled_ports_list)
 
         for port in ports_dict["ports"]:
             if isinstance(port, str):
@@ -224,11 +238,11 @@ class PortManager:
                 )[0]
 
             if isinstance(port, dict):
-                if not port.get("if", True):
+                if not require_bool(port, "if", True):
                     cands.pop(str(cand), None)
                     continue
 
-                cand.build_tests = port.get("tests", False) and enable_tests
+                cand.build_tests = require_bool(port, "tests", False) and enable_tests
 
                 use_flags = port.get("use", None)
                 if use_flags:

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -11,6 +11,7 @@
 
 import pytest
 import os
+import tempfile
 
 from resolvelib.resolvers import (
     ResolutionImpossible,
@@ -19,6 +20,7 @@ from resolvelib.resolvers import (
 from port_manager.port_manager import PortManager
 from port_manager.version import PhxVersion
 from port_manager.logger import LogLevel, logger
+from port_manager import build_layer
 
 PREFIX_BUILD = "normal_port_install_dir"
 PREFIX_BUILD_VERSIONED = "versioned_port_install_dir"
@@ -368,3 +370,34 @@ def test_ports_to_build_disable_bad_format(fix):
         with pytest.raises(SystemExit) as exc:
             run_dry_build(all_ports, to_build)
         assert exc.value.code == 1
+
+
+def assert_port_yaml_parsing(
+    port_yaml_contents: str, expected_dict: build_layer.PortsToBuildDict | None
+):
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        f.write(port_yaml_contents)
+        f.seek(0)
+        assert build_layer.get_ports_to_build(f.name) == expected_dict
+
+
+def test_port_yaml_jinja_bool_parsing(fix, monkeypatch):
+    yaml = "var: {{ bool(env.VAR) }}"
+
+    for true_str in ["y", "yes", "1", "true", "True"]:
+        with monkeypatch.context() as m:
+            m.setenv("VAR", true_str)
+            assert_port_yaml_parsing(yaml, {"var": True})
+
+    for false_str in ["n", "no", "0", "false", "False"]:
+        with monkeypatch.context() as m:
+            m.setenv("VAR", false_str)
+            assert_port_yaml_parsing(yaml, {"var": False})
+
+    # Undefined variable passed to bool() should default to false
+    with monkeypatch.context() as m:
+        m.delenv("VAR", raising=False)
+        assert_port_yaml_parsing(
+            yaml,
+            {"var": False},
+        )

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -55,7 +55,7 @@ def build_find_ports(dct):
 
 
 def build_get_ports_to_build(dct):
-    def closure(port_yamls):
+    def closure(ports_yamls):
         return dct
 
     return closure
@@ -369,32 +369,95 @@ def test_ports_to_build_disable_bad_format(fix):
         assert exc.value.code == 1
 
 
-def assert_port_yaml_parsing(
-    port_yaml_contents: str, expected_dict: build_layer.PortsToBuildDict | None
+def assert_ports_yaml_parsing(
+    ports_yaml_contents: str, expected_dict: build_layer.PortsToBuildDict | None
 ):
     with tempfile.NamedTemporaryFile(mode="w+") as f:
-        f.write(port_yaml_contents)
+        f.write(ports_yaml_contents)
         f.seek(0)
         assert build_layer.get_ports_to_build(f.name) == expected_dict
 
 
-def test_port_yaml_jinja_bool_parsing(fix, monkeypatch):
+def dry_build_from_yaml(ports_yaml_contents, all_ports):
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+        f.write(ports_yaml_contents)
+        f.seek(0)
+
+        pm = PortManager(
+            [],
+            find_ports=build_find_ports(all_ports),
+            dry=True,
+            ports_yamls=f.name,
+            ports_dir="some_path",
+        )
+        pm.cmd_build()
+        return pm
+
+
+def test_ports_yaml_jinja_bool_parsing(fix, monkeypatch):
     yaml = "var: {{ bool(env.VAR) }}"
 
     for true_str in ["y", "yes", "1", "true", "True"]:
         with monkeypatch.context() as m:
             m.setenv("VAR", true_str)
-            assert_port_yaml_parsing(yaml, {"var": True})
+            assert_ports_yaml_parsing(yaml, {"var": True})
 
     for false_str in ["n", "no", "0", "false", "False"]:
         with monkeypatch.context() as m:
             m.setenv("VAR", false_str)
-            assert_port_yaml_parsing(yaml, {"var": False})
+            assert_ports_yaml_parsing(yaml, {"var": False})
 
     # Undefined variable passed to bool() should default to false
     with monkeypatch.context() as m:
         m.delenv("VAR", raising=False)
-        assert_port_yaml_parsing(
+        assert_ports_yaml_parsing(
             yaml,
             {"var": False},
         )
+
+
+def test_ports_yaml_jinja_bool_parsing_build(fix, monkeypatch):
+    all_ports = {
+        "foo-1.2.3": {},
+    }
+
+    yaml = """
+ports:
+- name: foo
+  if: {{ bool(env.BUILD_FOO) }}
+"""
+
+    for build_foo in ["y", "n"]:
+        with monkeypatch.context() as m:
+            m.setenv("BUILD_FOO", build_foo)
+            pm = dry_build_from_yaml(yaml, all_ports)
+            assert_version_mapping(pm, {"foo-1.2.3": {}} if build_foo == "y" else {})
+
+
+def test_ports_yaml_should_fail_when_str_in_bool_fields(fix):
+    all_ports = {
+        "foo-1.2.3": {},
+    }
+
+    yamls = [
+        """
+        ports:
+        - name: foo
+          if: 'False'
+        """,
+        """
+        tests: 'True'
+        ports:
+        - name: foo
+        """,
+        """
+        ports:
+        - name: foo
+          tests: 'True'
+        """,
+    ]
+
+    for yaml in yamls:
+        with pytest.raises(SystemExit) as exc:
+            dry_build_from_yaml(yaml, all_ports)
+        assert exc.value.code == 1

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -275,7 +275,7 @@ def test_ports_to_build_override(fix):
     to_build = {
         "ports": [
             {"name": "foo"},
-            {"name": "foo", "if": "False"},
+            {"name": "foo", "if": False},
         ]
     }
 

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -244,30 +244,27 @@ def test_install_path(fix):
     )
 
 
-def test_install_bad_env(fix):
-    del os.environ["PREFIX_BUILD"]
+def test_install_bad_env(fix, monkeypatch):
+    with monkeypatch.context() as m:
+        m.delenv("PREFIX_BUILD", raising=False)
+        all_ports = {"foo-1.2.3": {"requires": "bar>=1.1.1"}, "bar-2.0.0": {}}
+        to_build = {"ports": [{"name": "foo"}]}
 
-    all_ports = {"foo-1.2.3": {"requires": "bar>=1.1.1"}, "bar-2.0.0": {}}
-    to_build = {"ports": [{"name": "foo"}]}
+        with pytest.raises(EnvironmentError) as ex:
+            run_dry_build(all_ports, to_build)
+        assert ex.value.args[0] == "PREFIX_BUILD undefined"
 
-    with pytest.raises(EnvironmentError) as ex:
-        run_dry_build(all_ports, to_build)
-    assert ex.value.args[0] == "PREFIX_BUILD undefined"
+    with monkeypatch.context() as m:
+        m.delenv("PREFIX_BUILD_VERSIONED", raising=False)
 
-    os.environ["PREFIX_BUILD"] = PREFIX_BUILD
-
-    del os.environ["PREFIX_BUILD_VERSIONED"]
-
-    all_ports = {
-        "foo-1.2.3": {"requires": "bar>=1.1.1"},
-        "bar-2.0.0": {"conflicts": "barng>=0.0"},
-    }
-    to_build = {"ports": [{"name": "foo"}]}
-    with pytest.raises(EnvironmentError) as ex:
-        run_dry_build(all_ports, to_build)
-    assert ex.value.args[0] == "PREFIX_BUILD_VERSIONED undefined"
-
-    os.environ["PREFIX_BUILD_VERSIONED"] = PREFIX_BUILD_VERSIONED
+        all_ports = {
+            "foo-1.2.3": {"requires": "bar>=1.1.1"},
+            "bar-2.0.0": {"conflicts": "barng>=0.0"},
+        }
+        to_build = {"ports": [{"name": "foo"}]}
+        with pytest.raises(EnvironmentError) as ex:
+            run_dry_build(all_ports, to_build)
+        assert ex.value.args[0] == "PREFIX_BUILD_VERSIONED undefined"
 
 
 def test_ports_to_build_override(fix):


### PR DESCRIPTION
Allows to replace stuff like `{{ (env.LONG_TEST | default('')) == 'y' }}` on ports.yaml level with simple `{{ bool(env.LONG_TEST) }}`

JIRA: RTOS-1266

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: internal pytest
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
