### PR TITLE
port_manager: pass env to build_cand from port_prepare.sh only

### DIFF
--- a/port_manager/build_layer.py
+++ b/port_manager/build_layer.py
@@ -224,12 +224,15 @@ def prepare_cand(
     with os.fdopen(r_fd) as r:
         env_output = r.read()
 
+    # port_prepare outputs sanitized environment for future build_cand invocation
+    build_env = dict()
+
     for line in env_output.split("\0"):
         if "=" in line:
             key, value = line.split("=", 1)
-            env[key] = value
+            build_env[key] = value
 
-    return env
+    return build_env
 
 
 def build_cand(cand: Candidate, env: dict[str, str], roll_logs: bool):


### PR DESCRIPTION
Before the change, build_cand (port_build.sh) inherited a modified env from port_prepare.sh but it was merged to the initial host env. Thus, any removal of definitions from host env was ineffective.

Fixes phoenix-rtos/phoenix-rtos-project#1588

JIRA: RTOS-1266

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [X] New test added: micropython assertion: https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/130
- [X] Tested by hand on: ia32 on 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
