### PR TITLE
port_manager: allow to pass 2-elem filename array via `archive_filename`

### DIFF
--- a/port_manager/build_layer.py
+++ b/port_manager/build_layer.py
@@ -81,7 +81,7 @@ def find_ports(ports_dir: str) -> Generator[tuple[dict[str, str], Path]]:
         )
 
         if result.returncode != 0:
-            logger.error(f"during loading of {port_def}:\n", result.stderr)
+            logger.error(f"during loading of {port_def}:\n{result.stdout}")
             sys.exit(1)
 
         dct = json.loads(result.stdout)

--- a/port_manager/port_def_to_json.sh
+++ b/port_manager/port_def_to_json.sh
@@ -42,6 +42,10 @@ if [ -z "${source}" ]; then
 	: "${git_source?}"
 else
 	: "${archive_filename?}"
+
+	if ((${#archive_filename[@]} > 2)); then
+		b_die "archive_filename must have at most 2 elements, got ${#archive_filename[@]}"
+	fi
 fi
 
 : "${sha256?}"

--- a/port_manager/port_prepare.sh
+++ b/port_manager/port_prepare.sh
@@ -79,7 +79,7 @@ if [ ! -d "${PREFIX_PORT_WORKDIR}" ]; then
 		check_size_sha256 "${actual_size}" "${actual_sha256}"
 	else
 		# shellcheck disable=2154 # archive_filename loaded from port.def.sh
-		b_port_download "${source}/" "${archive_filename}"
+		b_port_download "${source}/" "${archive_filename[@]}"
 
 		archive_path="${PREFIX_PORT}/${archive_filename}"
 		actual_size="$(wc -c <"${archive_path}")"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows to specify a custom archive filename if its name differs between source and mirror URLs. This maps to the signature of b_port_download().

The previous behavior (e.g. `archive_filename="foo-1.2.3.tar.gz"`) still works.

JIRA: RTOS-1266

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
