### PR TITLE
port_manager: allow to specify conflict with different version of itself

### DIFF
--- a/port_manager/main.py
+++ b/port_manager/main.py
@@ -22,7 +22,8 @@ def main() -> None:
         pm = PortManager(sys.argv)
         pm.run_cmd()
     except resolvelib.resolvers.ResolverException:
-        pass
+        # handled already, just exit (thrown for test purposes)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/port_manager/port_build.sh
+++ b/port_manager/port_build.sh
@@ -30,7 +30,7 @@ export PREFIX_H="${PREFIX_PORT_INSTALL}/include"
 export PREFIX_A="${PREFIX_PORT_INSTALL}/lib"
 
 # TODO: p_clean() ?
-# [[ $(type -t p_common) == function ]] && p_common # definition is optional
+[[ $(type -t p_common) == function ]] && p_common # definition is optional
 
 p_build
 

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -100,6 +100,13 @@ def test_port_resolution_conflicts_itself(fix):
         run_dry_build(all_ports, to_build)
 
 
+def test_port_resolution_conflicts_older_version(fix):
+    all_ports = {"foo-1.2.3": {"conflicts": "foo!=1.2.3"}}
+    to_build = {"ports": [{"name": "foo"}]}
+
+    run_dry_build(all_ports, to_build)
+
+
 def assert_version_mapping(pm, port_mappings, phoenix_ver=PHOENIX_VER):
     deps_to_install = 0
 

--- a/port_manager/requirements.py
+++ b/port_manager/requirements.py
@@ -48,6 +48,8 @@ def constraint_satisfied(candidate_version: PhxVersion, constraint: Constraint) 
             op = operator.gt
         case "<":
             op = operator.lt
+        case "!=":
+            op = operator.ne
         case _:
             sys.exit(f"invalid/unsupported relation: '{relation}'")
     return op(candidate_version, constraint_version)
@@ -93,7 +95,13 @@ class ConflictRequirement(BaseRequirement):
         return self._cname
 
     def is_satisfied_by(self, candidate: Candidate) -> bool:
-        return self._cname != candidate.name
+        """
+        Checks if a candidate is compatible with this conflict requirement.
+
+        NOTE: This is a negation of the parent's method. It returns True if
+        the candidate does NOT fall into the conflicting version range.
+        """
+        return not super().is_satisfied_by(candidate)
 
 
 class OptionalRequirement(BaseRequirement):

--- a/port_manager/resolver.py
+++ b/port_manager/resolver.py
@@ -140,14 +140,15 @@ class PhxProvider(resolvelib.AbstractProvider):
             logger.debug(candidate, "conflict list:", candidate.iter_conflicts())
             for conflict in candidate.iter_conflicts():
                 if conflict.cname in requirements:
-                    logger.debug(
-                        candidate,
-                        "conflicts with",
-                        conflict.cname,
-                        "but it is in requirements",
-                    )
-                    good = False
-                    break
+                    if identifier != conflict.cname or not conflict.is_satisfied_by(candidate):
+                        logger.debug(
+                            candidate,
+                            "conflicts with",
+                            conflict.cname,
+                            "but it is in requirements",
+                        )
+                        good = False
+                        break
             for requirement in requirements[identifier]:
                 if not requirement.is_satisfied_by(candidate):
                     logger.debug(candidate, "doesn't satisfy", requirement)

--- a/port_manager/version.py
+++ b/port_manager/version.py
@@ -76,7 +76,7 @@ class PhxVersionGrammar:
     no_version = (
         pp.Empty().set_name("version").set_parse_action(lambda: PhxVersion("0.0"))
     )
-    version_op = pp.one_of(">= <= == > <")
+    version_op = pp.one_of(">= <= == > < !=")
     e1 = pp.Group(package + version_op + version) ^ pp.Group(
         package + no_version_op + no_version
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

While it's obvious that different versions of the same port are conflicting, it should be allowed to explicitly specify the conflict to highlight the conflict potential.

For instance, openssl-1.1.1a will have a conflict with "openssl>=3", to 1) express that it should be versioned 2) hint that there is another openssl version possible here.

JIRA: RTOS-1266

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [X] New test added: pytest
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
