### PR TITLE
build: add opt-in confirmation before clean build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -151,10 +151,19 @@ elif [ -z "$INTERCEPT_BUILD_TARGET_DIR" ] && [ -z "$INTERCEPT_REPORT_COMMAND" ];
 	fi
 fi
 
+: "${PHOENIX_ASK_BEFORE_CLEAN:=n}"
+
 #
 # Clean if requested
 #
 if [ "$B_CLEAN" = "y" ]; then
+	if [ "$PHOENIX_ASK_BEFORE_CLEAN" = "y" ] && [ -t 0 ]; then
+		read -r -p "Clean build dirs? [y/N] " response
+		if [[ ! "$response" =~ ^[Yy]$ ]]; then
+			exit 1
+		fi
+	fi
+
 	b_log "Cleaning build dirs"
 	rm -rf "$PREFIX_BUILD" "$PREFIX_BUILD_HOST"
 	rm -rf "$PREFIX_FS"


### PR DESCRIPTION
Accidental invocation of build with `clean` is painful on large projects and wastes time

TASK: RTOS-1324

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
