### PR TITLE
port_manager: introduce conditional deps, USE prop and constraints

### DIFF
--- a/port_manager/build_layer.py
+++ b/port_manager/build_layer.py
@@ -236,11 +236,25 @@ def prepare_cand(
     return build_env
 
 
+def clean_cand(cand: Candidate, env: dict[str, str]):
+    """Invokes port_clean.sh on a candidate"""
+    result = subprocess.run(
+        ["bash", str(PORT_MGMT_DIR / "port_clean.sh"), cand.definition_path],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if result.returncode != 0:
+        logger.error(f"Failed to clean {cand}:\n{result.stdout}")
+        sys.exit(1)
+
+
 def build_cand(cand: Candidate, env: dict[str, str], roll_logs: bool):
     """Invokes port_build.sh on a candidate"""
     log_file_path = os.path.join(env["PREFIX_PORT_BUILD"], "build.log")
 
-    # TODO: rebuild on ports.yaml (port-local) change and patches changes
+    # TODO: rebuild on changed patches
     logger.info("-> Build")
 
     proc = run_process(

--- a/port_manager/candidates.py
+++ b/port_manager/candidates.py
@@ -19,7 +19,8 @@ import sys
 
 from pathlib import Path
 
-from .requirements import OptionalRequirement, ConflictRequirement, Requirement
+from .requirements import ConflictRequirement, ConditionalRequirement, Requirement
+from .required_use import RequiredUseExpr, validate_required_use
 from .version import PhxVersion
 from .logger import logger
 from . import build_layer
@@ -37,6 +38,7 @@ class Candidate:
         definition_path: str,
         exposed_use_flags: list[str],
         desc: str = "",
+        required_use: list[RequiredUseExpr] | None = None,
     ) -> None:
         self._name = name
         self._version = version
@@ -51,6 +53,8 @@ class Candidate:
         self.build_tests = False
         self.exposed_use_flags = exposed_use_flags
         self.use_flags: list[str] = []
+        self.use_flags_origins: dict[str, list[str]] = {}
+        self.required_use: list[RequiredUseExpr] = required_use or []
         self.desc = desc
 
     @property
@@ -69,15 +73,45 @@ class Candidate:
     def __repr__(self) -> str:
         return f"{self.name}-{self.version}"
 
-    def set_use_flags(self, flags: Collection[str]) -> None:
+    def set_use_flags(self, flags: Collection[str], origin: str = "user") -> None:
         diff = list(set(flags) - set(self.exposed_use_flags))
         if diff:
             logger.error(f"unrecognized flags for {self}:", diff)
             sys.exit(1)
-        self.use_flags = list(flags)
+
+        new_flags = set(self.use_flags) | set(flags)
+
+        valid, err = validate_required_use(self.required_use, new_flags)
+        if not valid:
+            # Build origin trace for the conflicting flags
+            origins = dict(self.use_flags_origins)
+            for f in flags:
+                origins.setdefault(f, [])
+                if origin not in origins[f]:
+                    origins[f].append(origin)
+            trace = ", ".join(
+                f"+{f} (by {', '.join(o)})" for f, o in sorted(origins.items()) if f in new_flags
+            )
+            logger.error(f"REQUIRED_USE violated on {self}: {err}\n  Flag origins: {trace}")
+            sys.exit(1)
+
+        self.use_flags = list(new_flags)
+
+        for flag in flags:
+            if flag not in self.use_flags_origins:
+                self.use_flags_origins[flag] = []
+            if origin not in self.use_flags_origins[flag]:
+                self.use_flags_origins[flag].append(origin)
 
     def iter_dependencies(self) -> Iterable[Requirement]:
-        return self._requirements
+        """Returns an iterable with requirements that model the required
+        dependencies of the candidate. The iterable will contain
+        a ConditionalRequirement only if the candidate has enabled
+        the corresponding flag."""
+        return (
+            r for r in self._requirements
+            if not isinstance(r, ConditionalRequirement) or r.use_flag in self.use_flags
+        )
 
     def iter_conflicts(self) -> Iterable[ConflictRequirement]:
         return self._conflicts
@@ -88,22 +122,13 @@ class Candidate:
                 return True
         return False
 
-    def is_optional(self, candidate: Candidate) -> bool:
-        for req in self._requirements:
-            if (
-                req.name == candidate.name
-                and req.is_satisfied_by(candidate)
-                and isinstance(req, OptionalRequirement)
-            ):
-                return True
-        return False
-
     def to_dict(self, ports_dir: str) -> dict[str, str | list[str]]:
         return {
             "version": str(self.version),
-            "requirements": [str(r) for r in self.iter_dependencies()],
+            "requirements": [str(r) for r in self._requirements],
             "conflicts": [str(r) for r in self.iter_conflicts()],
             "port_def_path": str(Path(self.definition_path).relative_to(ports_dir)),
+            "required_use": [str(ru) for ru in self.required_use],
             "iuse": self.exposed_use_flags,
             "desc": self.desc,
         }
@@ -112,10 +137,7 @@ class Candidate:
         self, mapping: dict[str, Candidate]
     ) -> Generator[InstallableCandidate]:
         for dep in self.iter_dependencies():
-            if dep.name not in mapping:
-                # this is an optional dependency, otherwise resolver would
-                # raise resolution error earlier
-                continue
+            assert dep.name in mapping, "mapping should be a superset of iter_dependencies()"
             cand = mapping[dep.name]
             if not isinstance(cand, InstallableCandidate):
                 continue
@@ -137,7 +159,7 @@ class OsCandidate(Candidate):
     """
 
     def __init__(self, name: str, version: PhxVersion) -> None:
-        super().__init__(name, version, [], [], "", [])
+        super().__init__(name, version, [], [], "", [], required_use=[])
 
     def __repr__(self) -> str:
         return f"OS:{self.name}-{self.version}"
@@ -166,8 +188,11 @@ class InstallableCandidate(Candidate):
         dep_of: Candidate | None = None,
         **kwargs,
     ) -> None:
-        if self.installed:
-            return
+        # Validate REQUIRED_USE before installing (set_use_flags may not be called)
+        valid, err = validate_required_use(self.required_use, set(self.use_flags))
+        if not valid:
+            logger.error(f"REQUIRED_USE violated on {self}: {err}")
+            sys.exit(1)
 
         dry = kwargs.get("dry", False)
         roll_logs = kwargs.get("roll_logs", False)
@@ -198,6 +223,11 @@ class InstallableCandidate(Candidate):
 
         logger.nest(self.name)
 
+        if self.installed:
+            logger.info("Already installed")
+            logger.unnest()
+            return
+
         start = time.time()
 
         port_env["PREFIX_PORT_INSTALL"] = self.install_path
@@ -209,14 +239,8 @@ class InstallableCandidate(Candidate):
                 logger.info("-> Build deps")
                 deps_info_emitted = True
 
-            if self.is_optional(dep_cand):
-                logger.warning(
-                    f"{dep_cand} is an optional dependency and must be explicitly enabled first. Skipping"
-                )
-            else:
-                if not dep_cand.installed:
-                    dep_cand.install(mapping, dep_of=self, **kwargs)
-                dep_cand.needed_by.append(self)
+            dep_cand.install(mapping, dep_of=self, **kwargs)
+            dep_cand.needed_by.append(self)
 
         lib_path_set = set()
         pkg_config_path_set = set()

--- a/port_manager/port.subr
+++ b/port_manager/port.subr
@@ -90,17 +90,6 @@ b_install_host() {
 	done
 }
 
-# shellcheck disable=2317 # may be used in p_* functions
-# b_optional_dir(dep_name)
-#  Returns installation directory of an optional dependency named ${dep_name}.
-#  This directory is a root to `lib` and `include` directories containing
-#  dependency libraries and headers. If optional dependency is not installed,
-#  returns empty string.
-b_optional_dir() {
-	local dependency_name_env_name="PORT_DEP_${1?dependency_name}"
-	echo "${!dependency_name_env_name}"
-}
-
 # shellcheck disable=2317 # as above
 # b_dependency_dir(dep_name)
 #  Returns installation directory of a required dependency named ${dep_name}.
@@ -109,9 +98,10 @@ b_optional_dir() {
 #  installed, returns empty string (but if this happens, your port.def.sh is
 #  wrong!).
 b_dependency_dir() {
-	local res, dependency_name
+	local res dependency_name dependency_name_env_name
 	dependency_name="${1?}"
-	res="$(b_optional_dir "${dependency_name}")"
+	dependency_name_env_name="PORT_DEP_${dependency_name}"
+	res="${!dependency_name_env_name}"
 	if [[ -z "$res" ]]; then
 		b_die "dependency for ${dependency_name} required but not installed!"
 	fi
@@ -137,4 +127,4 @@ b_use_ensure() {
 # TODO: add more USE flag helpers
 
 export -f b_port_download b_port_apply_patches b_install_host \
-	b_optional_dir b_dependency_dir b_use b_use_ensure
+	b_dependency_dir b_use b_use_ensure

--- a/port_manager/port_clean.sh
+++ b/port_manager/port_clean.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Port management
+#
+# Port cleaning script (invoked by port_manager.py)
+#
+# Copyright 2026 Phoenix Systems
+# Author: Adam Greloch
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+set -e
+
+def_path="${1?}"
+
+source "$(dirname "${BASH_SOURCE[0]}")/port_internal.subr"
+load_port_def "${def_path}"
+
+# shellcheck disable=2154 # name, version loaded from port.def.sh
+PREFIX_PORT_BUILD="${PREFIX_BUILD?}/port-sources/${name}-${version}"
+
+echo "CLEAN: ${name}-${version}"
+
+if [ -d "${PREFIX_PORT_BUILD}" ]; then
+	rm -rf "${PREFIX_PORT_BUILD}"
+fi

--- a/port_manager/port_def_to_json.sh
+++ b/port_manager/port_def_to_json.sh
@@ -73,17 +73,17 @@ fi
 jq -n \
 	--arg namever "${name}-${version}" \
 	--arg requires "${depends}" \
-	--arg optional "${optional}" \
 	--arg conflicts "${conflicts}" \
 	--arg iuse "${iuse}" \
+	--arg required_use "${required_use}" \
 	--arg supports "${supports}" \
 	--arg desc "${desc}" \
 	'{
     namever: $namever,
     requires: $requires,
-    optional: $optional,
     conflicts: $conflicts,
     iuse: $iuse,
+    required_use: $required_use,
     supports: $supports,
     desc: $desc,
   }'

--- a/port_manager/port_internal.subr
+++ b/port_manager/port_internal.subr
@@ -66,13 +66,12 @@ load_port_def() {
 	unset src_path
 
 	unset conflicts
-
 	unset depends
-	unset optional
 
 	unset supports
 
 	unset iuse
+	unset required_use
 
 	unset p_common
 	unset p_prepare

--- a/port_manager/port_manager.py
+++ b/port_manager/port_manager.py
@@ -10,6 +10,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+# TODO: rebuild on use flags change in ports yaml (whole dependant chain should
+# also be rebuilt)
+
 from __future__ import annotations
 from typing import Any, TypeVar
 from collections.abc import Callable
@@ -27,31 +30,34 @@ from .version import PhxVersion, PhxVersionGrammar
 from .logger import logger, LogLevel
 from .requirements import (
     BaseRequirement,
-    OptionalRequirement,
     ConflictRequirement,
+    ConditionalRequirement,
     Constraint,
 )
 from .candidates import Candidate, OsCandidate, InstallableCandidate
 from .resolver import PhxResolver, CandidatesDict
+from .required_use import parse_required_use
 from . import build_layer
 
 T = TypeVar("T")
 
 
-def parse_requirements(s: str, f: Callable[[str, list[Constraint]], T]) -> list[T]:
+def parse_requirements(s: str, req_constructor: Callable[[str, list[Constraint]], T]) -> list[T]:
     requirements_objects = []
     if s:
-        requirements_tuples: dict[str, list[Constraint]] = dict()
-
-        res = PhxVersionGrammar.parse_string(s)
-        for rname, rel, ver in res:
-            if rname not in requirements_tuples:
-                requirements_tuples[rname] = []
-            requirements_tuples[rname].append((rel, ver))
-
-        for rname, constraints in requirements_tuples.items():
-            logger.debug(constraints)
-            requirements_objects.append(f(rname, constraints))
+        for elem in PhxVersionGrammar.parse_string(s):
+            if "cond_flag" in elem:
+                cond_flag = elem.cond_flag
+                for dep in elem.cond_deps:
+                    flags = list(dep.use_flags)
+                    requirements_objects.append(
+                        ConditionalRequirement(dep[0], [(dep[1], dep[2])], cond_flag, flags)
+                    )
+            else:
+                flags = list(elem.use_flags)
+                req = req_constructor(elem[0], [(elem[1], elem[2])])
+                req.propagated_use_flags = flags
+                requirements_objects.append(req)
 
     return requirements_objects
 
@@ -134,7 +140,6 @@ class PortManager:
             name, version = parse_namever(port["namever"])
 
             req = parse_requirements(port["requires"], BaseRequirement)
-            req += parse_requirements(port["optional"], OptionalRequirement)
             req += parse_requirements(port["supports"], BaseRequirement)
 
             conflicts = parse_requirements(
@@ -147,6 +152,11 @@ class PortManager:
 
             available_flags = port["iuse"].split()
 
+            # Parse REQUIRED_USE: Gentoo-like USE flag constraint expressions
+            # e.g. "^^ ( x1 x2 )" or "ssl? ( crypto )" or "?? ( a b c )"
+            required_use_str = port.get("required_use", "")
+            required_use_exprs = parse_required_use(required_use_str)
+
             self.add_candidate(
                 InstallableCandidate(
                     name,
@@ -156,8 +166,33 @@ class PortManager:
                     str(def_path),
                     available_flags,
                     port["desc"],
+                    required_use=required_use_exprs,
                 )
             )
+
+    def propagate_use_flags(self) -> None:
+        """Propagate USE flags from requirements to dependency candidates.
+
+        Iterates to a fixed point since newly propagated flags may activate
+        conditional dependencies that carry further propagations."""
+        changed = True
+        while changed:
+            # WARN: For now, the flag state is monotonic, so the fixed point is
+            # always reachable. This won't be the case once the flag negations
+            # (or any other monotonicity-breaking feature) are implemented.
+            changed = False
+            for mapping in self.mapping.values():
+                for cand in mapping.values():
+                    for req in cand.iter_dependencies():
+                        if not req.propagated_use_flags:
+                            continue
+                        if req.name not in mapping:
+                            continue
+                        dep_cand = mapping[req.name]
+                        new_flags = set(req.propagated_use_flags) - set(dep_cand.use_flags)
+                        dep_cand.set_use_flags(req.propagated_use_flags, origin=str(cand))
+                        if new_flags:
+                            changed = True
 
     def resolve(self, cands: list[InstallableCandidate]):
         user_requirements = dict()
@@ -264,7 +299,16 @@ class PortManager:
                 reasons.append("U")
             if port.needed_by:
                 reasons += [f"D:{p}" for p in port.needed_by]
-            ports_str += "\n * " + f"{port} ({', '.join(reasons)})"
+
+            flags_info = ""
+            if port.use_flags:
+                flag_details = []
+                for flag in port.use_flags:
+                    origins = port.use_flags_origins.get(flag, ["unknown"])
+                    flag_details.append(f"+{flag} (by {', '.join(origins)})")
+                flags_info = " [" + ", ".join(flag_details) + "]"
+
+            ports_str += "\n * " + f"{port} ({', '.join(reasons)}){flags_info}"
         logger.info(
             "Install summary:",
             ports_str,
@@ -292,6 +336,7 @@ class PortManager:
             )
 
         self.resolve(cands)
+        self.propagate_use_flags()
 
         for cand in cands:
             cand.user_required = True

--- a/port_manager/port_manager.py
+++ b/port_manager/port_manager.py
@@ -10,9 +10,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
-# TODO: rebuild on use flags change in ports yaml (whole dependant chain should
-# also be rebuilt)
-
 from __future__ import annotations
 from typing import Any, TypeVar
 from collections.abc import Callable
@@ -21,6 +18,7 @@ from collections.abc import Sequence, Generator
 import sys
 import time
 import json
+import os
 
 from pathlib import Path
 
@@ -88,6 +86,7 @@ class PortManager:
         | None = None,
         get_ports_to_build: Callable[[str], build_layer.PortsToBuildDict | None]
         | None = None,
+        state_dir: str | None = None,
     ) -> None:
         self.discovered_ports: CandidatesDict = dict()
         self.os_candidates_added = False
@@ -111,6 +110,8 @@ class PortManager:
 
         self.ports_installed: list[Candidate] = []
         self.ports_skipped: list[str] = []
+        self._state_dir = Path(state_dir) if state_dir else None
+        self.stale_ports: set[str] = set()
 
     def add_candidate(self, candidate: Candidate) -> None:
         name = candidate.name
@@ -193,6 +194,89 @@ class PortManager:
                         dep_cand.set_use_flags(req.propagated_use_flags, origin=str(cand))
                         if new_flags:
                             changed = True
+
+    def _get_state_dir(self) -> Path | None:
+        if self._state_dir:
+            return self._state_dir
+        if not self.dry:
+            return Path(build_layer.ensure_getenv("PREFIX_BUILD")) / ".port_state"
+        return None
+
+    @staticmethod
+    def _build_state(cand: InstallableCandidate) -> dict:
+        return {"use_flags": sorted(cand.use_flags), "tests": cand.build_tests}
+
+    def clean_stale_ports(self) -> None:
+        """Compare current USE flag state with the saved state from the last
+        build.  If any port's state changed, clean it and all transitive
+        dependents so they are rebuilt from scratch."""
+        state_dir = self._get_state_dir()
+        if state_dir is None:
+            return
+
+        # Collect all unique InstallableCandidate objects across mappings
+        all_cands: dict[str, InstallableCandidate] = {
+            str(c): c
+            for mapping in self.mapping.values()
+            for c in mapping.values()
+            if isinstance(c, InstallableCandidate)
+        }
+
+        # Find directly stale candidates (saved state differs from current)
+        for nv, c in all_cands.items():
+            state_file = state_dir / f"{nv}.json"
+            if not state_file.exists():
+                continue
+            with open(state_file, encoding="utf-8") as f:
+                saved = json.load(f)
+            if saved != self._build_state(c):
+                self.stale_ports.add(nv)
+
+        if not self.stale_ports:
+            return
+
+        # Build reverse dependency graph: dep -> set of dependents
+        rdeps: dict[str, set[str]] = {nv: set() for nv in all_cands}
+        for mapping in self.mapping.values():
+            for c in mapping.values():
+                if not isinstance(c, InstallableCandidate):
+                    continue
+                for dep_c in c.iter_installable_dep_cands(mapping):
+                    rdeps[str(dep_c)].add(str(c))
+
+        # Propagate staleness transitively to dependents
+        queue = list(self.stale_ports)
+        while queue:
+            nv = queue.pop()
+            for dep_nv in rdeps.get(nv, []):
+                if dep_nv not in self.stale_ports:
+                    self.stale_ports.add(dep_nv)
+                    queue.append(dep_nv)
+
+        # Clean all stale candidates
+        for nv in sorted(self.stale_ports):
+            c = all_cands[nv]
+            logger.info(f"Build state changed for {c}, cleaning")
+            if not self.dry:
+                env = os.environ.copy()
+                env["PREFIX_PORT_INSTALL"] = c.install_path
+                build_layer.clean_cand(c, env)
+            # Remove saved state so it is re-saved after rebuild
+            state_file = state_dir / f"{nv}.json"
+            state_file.unlink(missing_ok=True)
+
+    def save_build_state(self) -> None:
+        """Persist build state for all installed ports."""
+        state_dir = self._get_state_dir()
+        if state_dir is None:
+            return
+        state_dir.mkdir(parents=True, exist_ok=True)
+        for cand in self.ports_installed:
+            if not isinstance(cand, InstallableCandidate):
+                continue
+            state_file = state_dir / f"{cand}.json"
+            with open(state_file, "w", encoding="utf-8") as f:
+                json.dump(self._build_state(cand), f)
 
     def resolve(self, cands: list[InstallableCandidate]):
         user_requirements = dict()
@@ -337,6 +421,7 @@ class PortManager:
 
         self.resolve(cands)
         self.propagate_use_flags()
+        self.clean_stale_ports()
 
         for cand in cands:
             cand.user_required = True
@@ -346,6 +431,8 @@ class PortManager:
                 dry=self.dry,
                 ports_installed=self.ports_installed,
             )
+
+        self.save_build_state()
 
         stop = time.time()
 

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -62,7 +62,7 @@ def build_get_ports_to_build(dct):
     return closure
 
 
-def run_dry_build(all_ports, to_build):
+def run_dry_build(all_ports, to_build, state_dir=None):
     pm = PortManager(
         [],
         get_ports_to_build=build_get_ports_to_build(to_build),
@@ -70,6 +70,7 @@ def run_dry_build(all_ports, to_build):
         dry=True,
         ports_yamls="yaml1:yaml2",
         ports_dir="some_path",
+        state_dir=str(state_dir) if state_dir else None,
     )
     pm.cmd_build()
     return pm
@@ -801,3 +802,125 @@ def test_use_flag_multiple_origins(fix):
     assert "ssl" in bar_from_foo.use_flags
     assert "foo-1.2.3" in bar_from_foo.use_flags_origins["ssl"]
     assert "baz-1.0.0" in bar_from_foo.use_flags_origins["ssl"]
+
+
+def test_build_state_saved(fix, tmp_path):
+    """After a dry build with state_dir, state files should be written."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl"}}
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    run_dry_build(all_ports, to_build, state_dir=tmp_path)
+
+    state_file = tmp_path / "foo-1.2.3.json"
+    assert state_file.exists()
+
+    import json
+
+    state = json.loads(state_file.read_text())
+    assert state == {"use_flags": ["ssl"], "tests": False}
+
+
+def test_no_stale_when_flags_unchanged(fix, tmp_path):
+    """Second build with same flags should detect no stale ports."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl"}}
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    run_dry_build(all_ports, to_build, state_dir=tmp_path)
+
+    pm = run_dry_build(all_ports, to_build, state_dir=tmp_path)
+    assert not pm.stale_ports
+
+
+def test_stale_on_flag_add(fix, tmp_path):
+    """Adding a USE flag should mark the port as stale."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl crypto"}}
+
+    run_dry_build(all_ports, {"ports": [{"name": "foo", "use": ["ssl"]}]}, state_dir=tmp_path)
+    pm = run_dry_build(
+        all_ports, {"ports": [{"name": "foo", "use": ["ssl", "crypto"]}]}, state_dir=tmp_path
+    )
+    assert "foo-1.2.3" in pm.stale_ports
+
+
+def test_stale_on_flag_remove(fix, tmp_path):
+    """Removing a USE flag should mark the port as stale."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl crypto"}}
+
+    run_dry_build(
+        all_ports, {"ports": [{"name": "foo", "use": ["ssl", "crypto"]}]}, state_dir=tmp_path
+    )
+    pm = run_dry_build(
+        all_ports, {"ports": [{"name": "foo", "use": ["ssl"]}]}, state_dir=tmp_path
+    )
+    assert "foo-1.2.3" in pm.stale_ports
+
+
+def test_stale_propagates_to_dependents(fix, tmp_path):
+    """If a dep's flags change, all ports depending on it are also stale."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0"},
+        "bar-2.0.0": {"iuse": "ssl"},
+    }
+
+    run_dry_build(
+        all_ports, {"ports": [{"name": "foo"}, {"name": "bar", "use": ["ssl"]}]},
+        state_dir=tmp_path,
+    )
+    pm = run_dry_build(
+        all_ports, {"ports": [{"name": "foo"}, {"name": "bar"}]},
+        state_dir=tmp_path,
+    )
+    # bar changed (ssl removed), foo depends on bar -> both stale
+    assert "bar-2.0.0" in pm.stale_ports
+    assert "foo-1.2.3" in pm.stale_ports
+
+
+def test_stale_state_file_updated_after_rebuild(fix, tmp_path):
+    """After a stale port is rebuilt, its state file should reflect the new flags."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl crypto"}}
+
+    run_dry_build(all_ports, {"ports": [{"name": "foo", "use": ["ssl"]}]}, state_dir=tmp_path)
+    run_dry_build(
+        all_ports, {"ports": [{"name": "foo", "use": ["ssl", "crypto"]}]}, state_dir=tmp_path
+    )
+
+    import json
+
+    state = json.loads((tmp_path / "foo-1.2.3.json").read_text())
+    assert state == {"use_flags": ["crypto", "ssl"], "tests": False}
+
+
+def test_stale_via_propagated_flags(fix, tmp_path):
+    """Propagated flag change triggers stale detection."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[ssl]"},
+        "bar-2.0.0": {"iuse": "ssl crypto"},
+    }
+    run_dry_build(all_ports, {"ports": [{"name": "foo"}]}, state_dir=tmp_path)
+
+    # Now foo propagates both ssl and crypto
+    all_ports2 = {
+        "foo-1.2.3": {"requires": "bar>=1.0[ssl,crypto]"},
+        "bar-2.0.0": {"iuse": "ssl crypto"},
+    }
+    pm = run_dry_build(all_ports2, {"ports": [{"name": "foo"}]}, state_dir=tmp_path)
+
+    # bar's flags changed (gained crypto) -> bar and foo are stale
+    assert "bar-2.0.0" in pm.stale_ports
+    assert "foo-1.2.3" in pm.stale_ports
+
+
+def test_first_build_no_stale(fix, tmp_path):
+    """First build (no saved state) should not mark anything as stale."""
+    all_ports = {"foo-1.2.3": {"iuse": "ssl"}}
+    pm = run_dry_build(all_ports, {"ports": [{"name": "foo", "use": ["ssl"]}]}, state_dir=tmp_path)
+    assert not pm.stale_ports
+
+
+def test_stale_on_tests_flag_change(fix, tmp_path):
+    """Changing the tests flag should also trigger a rebuild."""
+    all_ports = {"foo-1.2.3": {}}
+
+    run_dry_build(all_ports, {"ports": [{"name": "foo"}]}, state_dir=tmp_path)
+    pm = run_dry_build(
+        all_ports, {"ports": [{"name": "foo", "tests": True}]}, state_dir=tmp_path
+    )
+    assert "foo-1.2.3" in pm.stale_ports

--- a/port_manager/port_manager_test.py
+++ b/port_manager/port_manager_test.py
@@ -44,9 +44,10 @@ def build_find_ports(dct):
 
             port_def.setdefault("supports", "phoenix>=3.3")
             port_def.setdefault("iuse", "")
+            port_def.setdefault("required_use", "")
             port_def.setdefault("desc", "")
 
-            for field in ["requires", "optional", "conflicts"]:
+            for field in ["requires", "conflicts"]:
                 port_def.setdefault(field, [])
 
             yield (port_def, os.path.join("somedir", name))
@@ -77,18 +78,6 @@ def run_dry_build(all_ports, to_build):
 def test_port_resolution_simple(fix):
     all_ports = {"foo-1.2.3": {"requires": "bar>=1.1.1"}, "bar-2.0.0": {}}
     to_build = {"ports": [{"name": "foo"}]}
-    run_dry_build(all_ports, to_build)
-
-
-def test_port_resolution_depends_optional(fix):
-    all_ports = {
-        "foo-1.2.3": {"requires": "bar>=1.1.1", "optional": "baz>=3.2.1"},
-        "bar-2.0.0": {},
-    }
-    to_build = {"ports": [{"name": "foo"}]}
-    run_dry_build(all_ports, to_build)
-
-    all_ports["baz-3.2.1"] = {}
     run_dry_build(all_ports, to_build)
 
 
@@ -340,27 +329,9 @@ def test_ports_to_build_disable_required_dependency(fix):
         run_dry_build(all_ports, to_build)
 
 
-def test_ports_to_build_disable_optional_dependency(fix):
-    all_ports = {
-        "foo-1.2.3": {"optional": "bar>=1.1.1"},
-        "bar-2.0.0": {},
-    }
-    to_build = {
-        "ports": [
-            {"name": "foo"},
-        ],
-        "disabled-ports": [
-            "bar",
-        ],
-    }
-
-    pm = run_dry_build(all_ports, to_build)
-    assert_version_mapping(pm, {"foo-1.2.3": {}})
-
-
 def test_ports_to_build_disable_bad_format(fix):
     all_ports = {
-        "foo-1.2.3": {"optional": "bar>=1.1.1"},
+        "foo-1.2.3": {"requires": "bar>=1.1.1"},
         "bar-2.0.0": {},
     }
 
@@ -468,3 +439,365 @@ def test_ports_yaml_should_fail_when_str_in_bool_fields(fix):
         with pytest.raises(SystemExit) as exc:
             dry_build_from_yaml(yaml, all_ports)
         assert exc.value.code == 1
+
+
+def test_conditional_dep_flag_enabled(fix):
+    """When the USE flag is enabled, the conditional dependency should be resolved."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "ssl ? ( bar>=1.1.1 )", "iuse": "ssl"},
+        "bar-2.0.0": {},
+    }
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {"bar": "2.0.0"}})
+
+
+def test_conditional_dep_flag_disabled(fix):
+    """When the USE flag is not enabled, the conditional dependency should be skipped."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "ssl ? ( bar>=1.1.1 )", "iuse": "ssl"},
+        "bar-2.0.0": {},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {}})
+
+
+def test_conditional_dep_missing_when_enabled(fix):
+    """When the USE flag is enabled but the conditional dep is unavailable, resolution should fail."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "ssl ? ( bar>=1.1.1 )", "iuse": "ssl"},
+    }
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    with pytest.raises(ResolutionImpossible):
+        run_dry_build(all_ports, to_build)
+
+
+def test_use_flag_propagation(fix):
+    """USE flags should be propagated to the dependency."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.1.1[crypto]"},
+        "bar-2.0.0": {"iuse": "crypto"},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {"bar": "2.0.0"}})
+
+    # Check that 'crypto' flag was propagated to bar
+    bar_cand = pm.mapping["foo-1.2.3"]["bar"]
+    assert "crypto" in bar_cand.use_flags
+
+
+def test_use_flag_propagation_bad_flag(fix):
+    """Propagating a USE flag not in the dependency's iuse should fail."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.1.1[nonexistent]"},
+        "bar-2.0.0": {"iuse": "crypto"},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_conditional_dep_with_use_propagation(fix):
+    """Conditional dep with USE flag propagation: ssl ? ( bar>=1.1.1[crypto] )."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "ssl ? ( bar>=1.1.1[crypto] )", "iuse": "ssl"},
+        "bar-2.0.0": {"iuse": "crypto"},
+    }
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {"bar": "2.0.0"}})
+
+    bar_cand = pm.mapping["foo-1.2.3"]["bar"]
+    assert "crypto" in bar_cand.use_flags
+
+
+def test_conditional_dep_with_use_propagation_flag_disabled(fix):
+    """When the condition flag is disabled, the dep (and its USE propagation) should be skipped."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "ssl ? ( bar>=1.1.1[crypto] )", "iuse": "ssl"},
+        "bar-2.0.0": {"iuse": "crypto"},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {}})
+
+
+def test_mixed_conditional_and_unconditional(fix):
+    """Mix of conditional and unconditional deps in the same requires string."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "baz>=1.0 ssl ? ( bar>=1.1.1 )", "iuse": "ssl"},
+        "bar-2.0.0": {},
+        "baz-1.5.0": {},
+    }
+    to_build = {"ports": [{"name": "foo", "use": ["ssl"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {"bar": "2.0.0", "baz": "1.5.0"}})
+
+    # Without ssl flag
+    to_build_no_ssl = {"ports": [{"name": "foo"}]}
+    pm2 = run_dry_build(all_ports, to_build_no_ssl)
+    assert_version_mapping(pm2, {"foo-1.2.3": {"baz": "1.5.0"}})
+
+
+def test_use_flag_additive_propagation(fix):
+    """foo requests bar[ssl], baz also depends on bar (no flags). ssl should still be set."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[ssl]"},
+        "baz-1.0.0": {"requires": "bar>=1.0"},
+        "bar-2.0.0": {"iuse": "ssl"},
+    }
+    to_build = {"ports": [{"name": "foo"}, {"name": "baz"}]}
+    pm = run_dry_build(all_ports, to_build)
+
+    bar_from_foo = pm.mapping["foo-1.2.3"]["bar"]
+    assert "ssl" in bar_from_foo.use_flags
+
+
+def test_required_use_at_most_one_conflict(fix):
+    """?? ( x1 x2 ): foo requests bar[x1], baz requests bar[x2] -> error."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[x1]"},
+        "baz-1.0.0": {"requires": "bar>=1.0[x2]"},
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "?? ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "foo"}, {"name": "baz"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_at_most_one_no_conflict(fix):
+    """?? ( x1 x2 ): foo requests bar[x1], baz requests bar[x3] -> ok."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[x1]"},
+        "baz-1.0.0": {"requires": "bar>=1.0[x3]"},
+        "bar-2.0.0": {"iuse": "x1 x2 x3", "required_use": "?? ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "foo"}, {"name": "baz"}]}
+    pm = run_dry_build(all_ports, to_build)
+
+    bar_from_foo = pm.mapping["foo-1.2.3"]["bar"]
+    assert "x1" in bar_from_foo.use_flags
+    assert "x3" in bar_from_foo.use_flags
+
+
+def test_required_use_at_most_one_none_set(fix):
+    """?? ( x1 x2 ): no flags set -> ok (zero is fine)."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0"},
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "?? ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert_version_mapping(pm, {"foo-1.2.3": {"bar": "2.0.0"}})
+
+
+def test_required_use_exactly_one(fix):
+    """^^ ( x1 x2 ): exactly one must be set."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "^^ ( x1 x2 )"},
+    }
+    # One set -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["x1"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert "x1" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+
+
+def test_required_use_exactly_one_none(fix):
+    """^^ ( x1 x2 ): none set -> error."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "^^ ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "bar"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_exactly_one_both(fix):
+    """^^ ( x1 x2 ): both set -> error."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "^^ ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "bar", "use": ["x1", "x2"]}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_any_of(fix):
+    """|| ( x1 x2 ): at least one must be set."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "|| ( x1 x2 )"},
+    }
+    # One set -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["x2"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert "x2" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+
+    # Both set -> also ok
+    to_build_both = {"ports": [{"name": "bar", "use": ["x1", "x2"]}]}
+    pm2 = run_dry_build(all_ports, to_build_both)
+    assert "x1" in pm2.mapping["bar-2.0.0"]["bar"].use_flags
+
+
+def test_required_use_any_of_none(fix):
+    """|| ( x1 x2 ): none set -> error."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "|| ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "bar"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_conditional_positive(fix):
+    """ssl? ( crypto ): if ssl is set, crypto must be set."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "ssl crypto", "required_use": "ssl? ( crypto )"},
+    }
+    # ssl + crypto -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["ssl", "crypto"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert "ssl" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+    assert "crypto" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+
+    # no ssl -> ok (constraint doesn't apply)
+    to_build2 = {"ports": [{"name": "bar"}]}
+    run_dry_build(all_ports, to_build2)
+
+
+def test_required_use_conditional_positive_violated(fix):
+    """ssl? ( crypto ): ssl set but crypto not -> error."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "ssl crypto", "required_use": "ssl? ( crypto )"},
+    }
+    to_build = {"ports": [{"name": "bar", "use": ["ssl"]}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_conditional_negated(fix):
+    """!minimal? ( extras ): if minimal is NOT set, extras must be set."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "minimal extras", "required_use": "!minimal? ( extras )"},
+    }
+    # minimal not set, extras set -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["extras"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert "extras" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+
+    # minimal set -> ok (constraint doesn't apply)
+    to_build2 = {"ports": [{"name": "bar", "use": ["minimal"]}]}
+    run_dry_build(all_ports, to_build2)
+
+
+def test_required_use_conditional_negated_violated(fix):
+    """!minimal? ( extras ): minimal NOT set, extras NOT set -> error."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "minimal extras", "required_use": "!minimal? ( extras )"},
+    }
+    to_build = {"ports": [{"name": "bar"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_required_use_conditional_negative_child(fix):
+    """ssl? ( !gnutls ): if ssl is set, gnutls must be disabled."""
+    all_ports = {
+        "bar-2.0.0": {"iuse": "ssl gnutls", "required_use": "ssl? ( !gnutls )"},
+    }
+    # ssl without gnutls -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["ssl"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    assert "ssl" in pm.mapping["bar-2.0.0"]["bar"].use_flags
+
+    # ssl with gnutls -> error
+    to_build2 = {"ports": [{"name": "bar", "use": ["ssl", "gnutls"]}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build2)
+
+
+def test_required_use_multiple_exprs(fix):
+    """Multiple expressions: ^^ ( a b ) ssl? ( crypto )."""
+    all_ports = {
+        "bar-2.0.0": {
+            "iuse": "a b ssl crypto",
+            "required_use": "^^ ( a b ) ssl? ( crypto )",
+        },
+    }
+    # a set, ssl+crypto -> ok
+    to_build = {"ports": [{"name": "bar", "use": ["a", "ssl", "crypto"]}]}
+    pm = run_dry_build(all_ports, to_build)
+    bar = pm.mapping["bar-2.0.0"]["bar"]
+    assert set(bar.use_flags) == {"a", "ssl", "crypto"}
+
+    # a set, no ssl -> ok (conditional doesn't apply)
+    to_build2 = {"ports": [{"name": "bar", "use": ["b"]}]}
+    run_dry_build(all_ports, to_build2)
+
+    # both a and b set -> error (^^ violated)
+    to_build3 = {"ports": [{"name": "bar", "use": ["a", "b"]}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build3)
+
+    # a set, ssl without crypto -> error (conditional violated)
+    to_build4 = {"ports": [{"name": "bar", "use": ["a", "ssl"]}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build4)
+
+
+def test_required_use_propagation_conflict(fix):
+    """Propagated flags must also satisfy the dep's REQUIRED_USE.
+    foo->bar[x1], baz->bar[x2], bar has ?? ( x1 x2 ) -> error."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[x1]"},
+        "baz-1.0.0": {"requires": "bar>=1.0[x2]"},
+        "bar-2.0.0": {"iuse": "x1 x2", "required_use": "?? ( x1 x2 )"},
+    }
+    to_build = {"ports": [{"name": "foo"}, {"name": "baz"}]}
+    with pytest.raises(SystemExit):
+        run_dry_build(all_ports, to_build)
+
+
+def test_use_flag_origin_tracking(fix):
+    """USE flag origins should be recorded for traceability."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[crypto]"},
+        "bar-2.0.0": {"iuse": "crypto"},
+    }
+    to_build = {"ports": [{"name": "foo"}]}
+    pm = run_dry_build(all_ports, to_build)
+
+    bar_cand = pm.mapping["foo-1.2.3"]["bar"]
+    assert "crypto" in bar_cand.use_flags
+    assert "crypto" in bar_cand.use_flags_origins
+    assert "foo-1.2.3" in bar_cand.use_flags_origins["crypto"]
+
+
+def test_use_flag_origin_user(fix):
+    """Flags set in ports.yaml should have origin 'user'."""
+    all_ports = {
+        "foo-1.2.3": {"iuse": "debug"},
+    }
+    to_build = {"ports": [{"name": "foo", "use": ["debug"]}]}
+    pm = run_dry_build(all_ports, to_build)
+
+    foo_cand = pm.mapping["foo-1.2.3"]["foo"]
+    assert "debug" in foo_cand.use_flags
+    assert "user" in foo_cand.use_flags_origins["debug"]
+
+
+def test_use_flag_multiple_origins(fix):
+    """When both user and a parent propagate the same flag, both origins should be recorded."""
+    all_ports = {
+        "foo-1.2.3": {"requires": "bar>=1.0[ssl]"},
+        "baz-1.0.0": {"requires": "bar>=1.0[ssl]"},
+        "bar-2.0.0": {"iuse": "ssl"},
+    }
+    to_build = {"ports": [{"name": "foo"}, {"name": "baz"}]}
+    pm = run_dry_build(all_ports, to_build)
+
+    bar_from_foo = pm.mapping["foo-1.2.3"]["bar"]
+    assert "ssl" in bar_from_foo.use_flags
+    assert "foo-1.2.3" in bar_from_foo.use_flags_origins["ssl"]
+    assert "baz-1.0.0" in bar_from_foo.use_flags_origins["ssl"]

--- a/port_manager/required_use.py
+++ b/port_manager/required_use.py
@@ -1,0 +1,207 @@
+#
+# Port management
+#
+# REQUIRED_USE constraint parser and validator
+#
+# Implements Gentoo-like REQUIRED_USE semantics for USE flag constraints.
+# See: https://devmanual.gentoo.org/ebuild-writing/variables/index.html#required_use
+#
+# Supported syntax:
+#   ^^ ( a b c )     - exactly one of a, b, c must be enabled
+#   ?? ( a b c )     - at most one of a, b, c may be enabled
+#   || ( a b c )     - at least one of a, b, c must be enabled
+#   flag? ( b c )    - if flag is enabled, b and c must be enabled
+#   !flag? ( b )     - if flag is disabled, b must be enabled
+#   flag? ( !b )     - if flag is enabled, b must be disabled
+#
+# Copyright 2026 Phoenix Systems
+# Author: Adam Greloch
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+from __future__ import annotations
+from dataclasses import dataclass
+
+import pyparsing as pp
+
+
+@dataclass
+class RequiredUseExpr:
+    """Base class for REQUIRED_USE constraint expressions"""
+    pass
+
+
+@dataclass
+class ExactlyOneOf(RequiredUseExpr):
+    """^^ ( flag1 flag2 ... ) - exactly one must be enabled"""
+    flags: list[str]
+
+    def __str__(self) -> str:
+        return f"^^ ( {' '.join(self.flags)} )"
+
+
+@dataclass
+class AtMostOneOf(RequiredUseExpr):
+    """?? ( flag1 flag2 ... ) - zero or one may be enabled"""
+    flags: list[str]
+
+    def __str__(self) -> str:
+        return f"?? ( {' '.join(self.flags)} )"
+
+
+@dataclass
+class AnyOf(RequiredUseExpr):
+    """|| ( flag1 flag2 ... ) - at least one must be enabled"""
+    flags: list[str]
+
+    def __str__(self) -> str:
+        return f"|| ( {' '.join(self.flags)} )"
+
+
+@dataclass
+class Conditional(RequiredUseExpr):
+    """flag? ( required... ) or !flag? ( required... )
+    Children may be negated with ! prefix: flag? ( !other ) means
+    'if flag is enabled, other must be disabled'."""
+    flag: str
+    negated: bool
+    children: list[str]
+
+    def __str__(self) -> str:
+        prefix = "!" if self.negated else ""
+        return f"{prefix}{self.flag}? ( {' '.join(self.children)} )"
+
+
+class RequiredUseGrammar:
+    """
+    Grammar for parsing REQUIRED_USE constraint strings.
+
+    Examples:
+        >>> RequiredUseGrammar.parse_string("^^ ( a b c )")
+        [ExactlyOneOf(flags=['a', 'b', 'c'])]
+
+        >>> RequiredUseGrammar.parse_string("?? ( x1 x2 )")
+        [AtMostOneOf(flags=['x1', 'x2'])]
+
+        >>> RequiredUseGrammar.parse_string("ssl? ( crypto )")
+        [Conditional(flag='ssl', negated=False, children=['crypto'])]
+
+        >>> RequiredUseGrammar.parse_string("!minimal? ( extras )")
+        [Conditional(flag='minimal', negated=True, children=['extras'])]
+
+        >>> RequiredUseGrammar.parse_string("ssl? ( !gnutls )")
+        [Conditional(flag='ssl', negated=False, children=['!gnutls'])]
+    """
+
+    flag = pp.Word(pp.alphanums + "_")
+    neg_flag = pp.Combine(pp.Literal("!") + flag)
+    flag_item = neg_flag | flag
+
+    group_op = pp.one_of("^^ ?? ||")
+    group_expr = pp.Group(
+        group_op("op")
+        + pp.Suppress("(")
+        + pp.Group(pp.OneOrMore(flag))("flags")
+        + pp.Suppress(")")
+    )
+
+    cond_flag = pp.Combine(pp.Optional("!") + flag + pp.FollowedBy("?"))
+    cond_expr = pp.Group(
+        cond_flag("cond_flag")
+        + pp.Suppress("?")
+        + pp.Suppress("(")
+        + pp.Group(pp.OneOrMore(flag_item))("children")
+        + pp.Suppress(")")
+    )
+
+    expr = cond_expr | group_expr
+    grammar = pp.ZeroOrMore(expr)
+
+    @staticmethod
+    def _to_expr(parsed: pp.ParseResults) -> RequiredUseExpr:
+        if "op" in parsed:
+            flags = list(parsed["flags"])
+            op = parsed["op"]
+            cls = {"^^": ExactlyOneOf, "??": AtMostOneOf, "||": AnyOf}[op]
+            return cls(flags)
+        else:
+            raw = parsed["cond_flag"]
+            negated = raw.startswith("!")
+            flag = raw.lstrip("!")
+            children = list(parsed["children"])
+            return Conditional(flag, negated, children)
+
+    @staticmethod
+    def parse_string(s: str) -> list[RequiredUseExpr]:
+        result = RequiredUseGrammar.grammar.parse_string(s, parse_all=True)
+        return [RequiredUseGrammar._to_expr(item) for item in result]
+
+
+def parse_required_use(s: str) -> list[RequiredUseExpr]:
+    """Parse a REQUIRED_USE string into a list of constraint expressions."""
+    if not s or not s.strip():
+        return []
+    return RequiredUseGrammar.parse_string(s)
+
+
+def validate_required_use(
+    exprs: list[RequiredUseExpr], active_flags: set[str]
+) -> tuple[bool, str]:
+    """Check whether active_flags satisfy all REQUIRED_USE constraints.
+
+    Returns (is_valid, error_message). error_message is empty when valid.
+    """
+    for expr in exprs:
+        if isinstance(expr, ExactlyOneOf):
+            active = [f for f in expr.flags if f in active_flags]
+            if len(active) != 1:
+                return (
+                    False,
+                    f"exactly one of ({', '.join(expr.flags)}) required, "
+                    f"but {len(active)} enabled"
+                    + (f": {', '.join(active)}" if active else ""),
+                )
+
+        elif isinstance(expr, AtMostOneOf):
+            active = [f for f in expr.flags if f in active_flags]
+            if len(active) > 1:
+                return (
+                    False,
+                    f"at most one of ({', '.join(expr.flags)}) allowed, "
+                    f"but {len(active)} enabled: {', '.join(active)}",
+                )
+
+        elif isinstance(expr, AnyOf):
+            active = [f for f in expr.flags if f in active_flags]
+            if len(active) == 0:
+                return (
+                    False,
+                    f"at least one of ({', '.join(expr.flags)}) required",
+                )
+
+        elif isinstance(expr, Conditional):
+            condition_met = (
+                (expr.flag not in active_flags)
+                if expr.negated
+                else (expr.flag in active_flags)
+            )
+            if condition_met:
+                for child in expr.children:
+                    if child.startswith("!"):
+                        real_flag = child[1:]
+                        if real_flag in active_flags:
+                            return (
+                                False,
+                                f"{expr} violated: "
+                                f"{real_flag} must be disabled",
+                            )
+                    else:
+                        if child not in active_flags:
+                            return (
+                                False,
+                                f"{expr} violated: "
+                                f"{child} must be enabled",
+                            )
+
+    return True, ""

--- a/port_manager/requirements.py
+++ b/port_manager/requirements.py
@@ -57,16 +57,24 @@ def constraint_satisfied(candidate_version: PhxVersion, constraint: Constraint) 
 
 class BaseRequirement(Requirement):
     """Expresses requirement for given dependency versions, e.g. that version of
-    A must be >=1.0 and <=3.0"""
+    A must be >=1.0 and <=3.0
 
-    def __init__(self, name: str, constraints: Iterable[Constraint]) -> None:
+    Optionally carries propagated_use_flags: USE flags to enable on the
+    dependency candidate when it is installed."""
+
+    def __init__(self, name: str, constraints: Iterable[Constraint],
+                 propagated_use_flags: list[str] | None = None) -> None:
         self._name = name
         self.constraints = constraints
+        self.propagated_use_flags = propagated_use_flags or []
 
     def __repr__(self) -> str:
-        return self._name + ",".join(
+        base = self._name + ",".join(
             [rel + str(ver) for (rel, ver) in self.constraints]
         )
+        if self.propagated_use_flags:
+            return f"{base}[{','.join(self.propagated_use_flags)}]"
+        return base
 
     @property
     def name(self) -> str:
@@ -104,9 +112,14 @@ class ConflictRequirement(BaseRequirement):
         return not super().is_satisfied_by(candidate)
 
 
-class OptionalRequirement(BaseRequirement):
-    """Expresses optional requirement for given dependency versions. Can be
-    dropped by the resolver if unsatisfiable"""
+class ConditionalRequirement(BaseRequirement):
+    """A requirement that is only active when a specific USE flag is enabled
+    on the parent candidate."""
+
+    def __init__(self, name: str, constraints: Iterable[Constraint], use_flag: str,
+                 propagated_use_flags: list[str] | None = None) -> None:
+        super().__init__(name, constraints, propagated_use_flags)
+        self.use_flag = use_flag
 
     def __repr__(self) -> str:
-        return "[o]" + super().__repr__()
+        return f"{self.use_flag}? ({super().__repr__()})"

--- a/port_manager/resolver.py
+++ b/port_manager/resolver.py
@@ -30,7 +30,7 @@ from resolvelib.resolvers import Result
 
 from .logger import logger
 from .candidates import Candidate
-from .requirements import Requirement, BaseRequirement, OptionalRequirement
+from .requirements import Requirement, BaseRequirement
 from .version import PhxVersion
 
 if Version(resolvelib.__version__) >= Version("1.1.1"):
@@ -82,14 +82,9 @@ CandidatesDict = dict[str, dict[str, Candidate]]
 class PhxProvider(resolvelib.AbstractProvider):
     def __init__(self, all_candidates: CandidatesDict) -> None:
         self.all_candidates = all_candidates
-        self.masked_requirements: set[OptionalRequirement] = set()
 
     def identify(self, requirement_or_candidate: Requirement | Candidate) -> str:
         return requirement_or_candidate.name
-
-    def mask_optional(self, req: OptionalRequirement) -> None:
-        logger.debug("masking the optional", req)
-        self.masked_requirements.add(req)
 
     def narrow_requirement_selection(
         self,
@@ -175,25 +170,10 @@ class PhxProvider(resolvelib.AbstractProvider):
         return requirement.is_satisfied_by(candidate)
 
     def get_dependencies(self, candidate: Candidate) -> Iterable[Requirement]:
-        return (
-            r
-            for r in candidate.iter_dependencies()
-            if r is not None
-            if r not in self.masked_requirements
-        )
+        return candidate.iter_dependencies()
 
 
 class MyReporter(resolvelib.BaseReporter):
-    _redo = False
-
-    def __init__(self, provider) -> None:
-        self.provider = provider
-
-    def redo_with_masked_optional(self) -> bool:
-        res = self._redo
-        self._redo = False
-        return res
-
     def ending(self, state: State[RT, CT, KT]) -> None:
         logger.debug("ending", state)
 
@@ -203,41 +183,30 @@ class MyReporter(resolvelib.BaseReporter):
     def rejecting_candidate(self, criterion: Criterion[RT, CT], candidate: CT) -> None:
         for req_info in criterion.information:
             req, parent = req_info.requirement, req_info.parent
-            if isinstance(req, OptionalRequirement):
-                logger.debug(
-                    f"{parent} optional requirement for {req} unsatisfiable, dropping"
-                )
-                self._redo = True
-                self.provider.mask_optional(req)
-            else:
-                logger.debug(f"{parent} requirement for {req} unsatisfiable")
+            logger.debug(f"{parent} requirement for {req} unsatisfiable")
 
 
 class PhxResolver:
     def __init__(self, all_candidates: CandidatesDict) -> None:
         self.provider = PhxProvider(all_candidates)
-        self.reporter = MyReporter(self.provider)
+        self.reporter = MyReporter()
         self.resolver = resolvelib.Resolver(self.provider, self.reporter)
 
     def resolve(self, reqs: list[BaseRequirement]) -> Result[BaseRequirement, Candidate, KT]:
-        while True:
-            try:
-                return self.resolver.resolve(reqs)
-            except resolvelib.resolvers.ResolutionTooDeep as e:
-                logger.error(
-                    f"Requirements unsatisfiable despite {e.round_count} attempts"
+        try:
+            return self.resolver.resolve(reqs)
+        except resolvelib.resolvers.ResolutionTooDeep as e:
+            logger.error(
+                f"Requirements unsatisfiable despite {e.round_count} attempts"
+            )
+            # NOTE: rethrow resolution exceptions instead of sys.exit(1)
+            # to catch exact resolution failures in resolver tests
+            raise
+        except resolvelib.resolvers.ResolutionImpossible as e:
+            causes_strs = []
+            for cause in e.causes:
+                causes_strs.append(
+                    f"-> {cause.requirement} required by {cause.parent}"
                 )
-                # NOTE: rethrow resolution exceptions instead of sys.exit(1)
-                # to catch exact resolution failures in resolver tests
-                raise
-            except resolvelib.resolvers.ResolutionImpossible as e:
-                causes_strs = []
-                for cause in e.causes:
-                    causes_strs.append(
-                        f"-> {cause.requirement} required by {cause.parent}"
-                    )
-                logger.error("Requirements unsatisfiable:\n" + "\n".join(causes_strs))
-                if self.reporter.redo_with_masked_optional():
-                    logger.debug("Redoing resolution with masked optional")
-                else:
-                    raise
+            logger.error("Requirements unsatisfiable:\n" + "\n".join(causes_strs))
+            raise

--- a/port_manager/version.py
+++ b/port_manager/version.py
@@ -59,11 +59,14 @@ class PhxVersionGrammar:
     Grammar for parsing dependency requirement strings.
 
     Examples:
-        >>> PhxVersionGrammar.parse_string("foo>=1.1 bar<2.0")
+        >>> PhxVersionGrammar.parse_string("foo>=1.1 bar<2.0").as_list()
         [['foo', '>=', <Version('1.1')>], ['bar', '<', <Version('2.0')>]]
 
-        >>> PhxVersionGrammar.parse_string("foo>3")
+        >>> PhxVersionGrammar.parse_string("foo>3").as_list()
         [['foo', '>', <Version('3')>]]
+
+        >>> PhxVersionGrammar.parse_string("foo ? (foo >=1.1) bar==3").as_list()
+        [['foo', [['foo', '>=', <Version('1.1')>]]], ['bar', '==', <Version('3')>]]
     """
 
     package = pp.Word(pp.alphanums + "_")
@@ -77,12 +80,35 @@ class PhxVersionGrammar:
         pp.Empty().set_name("version").set_parse_action(lambda: PhxVersion("0.0"))
     )
     version_op = pp.one_of(">= <= == > < !=")
-    e1 = pp.Group(package + version_op + version) ^ pp.Group(
-        package + no_version_op + no_version
+
+    # USE flag propagation: dep>=ver[flag1,flag2]
+    use_flag = pp.Word(pp.alphanums + "_")
+    use_flags = pp.Suppress("[") + pp.delimited_list(use_flag) + pp.Suppress("]")
+    opt_use_flags = pp.Group(use_flags)("use_flags") | pp.Empty().set_parse_action(lambda: [])("use_flags")
+
+    # Base dependency expression (with optional USE flags)
+    dep_with_ver = pp.Group(package + version_op + version + opt_use_flags)
+    dep_without_ver = pp.Group(package + no_version_op + no_version + opt_use_flags)
+    dep_expr = dep_with_ver ^ dep_without_ver
+
+    # Conditional dependency: flag ? ( dep_expr ... )
+    cond_flag = pp.Word(pp.alphanums + "_")
+    cond_expr = pp.Group(
+        cond_flag("cond_flag") + pp.Suppress("?") + pp.Suppress("(") +
+        pp.Group(pp.OneOrMore(dep_expr))("cond_deps") +
+        pp.Suppress(")")
     )
-    e0 = e1 + pp.ZeroOrMore(e1)
+
+    e0 = pp.ZeroOrMore(cond_expr("conditional*") | dep_expr)
 
     @staticmethod
-    def parse_string(s: str) -> list[tuple[str, str, PhxVersion]]:
-        ret = PhxVersionGrammar.e0.parse_string(s)
-        return ret.as_list()
+    def parse_string(s: str) -> pp.ParseResults:
+        """Parse a requirement string.
+
+        Returns a pyparsing.ParseResults object. Each element is either:
+        - [name, op, version, use_flags] for unconditional deps
+        - Has 'cond_flag' and 'cond_deps' attributes for conditional deps where
+          each dep from cond_deps has a structure like the uncoditional dep
+          element.
+        """
+        return PhxVersionGrammar.e0.parse_string(s)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes shortly -->

Adds more Gentoo-like USE semantics such as:
* `required_use` field and its grammar: `?? (a b)`, `^^ (a b c)`, etc. (https://devmanual.gentoo.org/ebuild-writing/variables/index.html#required_use)
* conditional deps: `foo ? (foo >= 1.1)` - `foo` port required only if `foo` flag enabled (optional deps but better and more predictable)
* flag propagation: a port can request a dependency to be built with specific flags, e.g. `bar>=3.0[foo]` will require `bar` to be built with `foo` flag. The resolver takes a union of all flag requirements for the same dep and will fail if the final flag config conflicts `required_use`.

As the flag configuration possibilities can now highly impact other ports, the second commit introduces a proper clean build of a dep chain in case the modifications to port.def.sh or ports.yaml cause the final flag fixed point to change.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The optional requirement mechanism was too fragile to be useful and were automagic.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

**Breaking: removes the `optional` field from the port.def.sh format**

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [x] New test added: pytest
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
https://github.com/phoenix-rtos/phoenix-rtos-ports/pull/140
- [ ] I will merge this PR by myself when appropriate.
