### PR TITLE
port_manager: use future minor version as PHOENIX_VER

### DIFF
--- a/build-ports.sh
+++ b/build-ports.sh
@@ -12,17 +12,14 @@ PORT_MANAGER_FLAGS=(
 )
 
 function port_manager() {
-  cd "${PREFIX_PROJECT}/phoenix-rtos-build/" || exit
-  python3 -m "port_manager.main" "${PORT_MANAGER_FLAGS[@]}" "${@}"
+	cd "${PREFIX_PROJECT}/phoenix-rtos-build/" || exit
+	python3 -m "port_manager.main" "${PORT_MANAGER_FLAGS[@]}" "${@}"
 }
 
 if [ "$RAW_LOG" != 1 ]; then
-  PORT_MANAGER_FLAGS+=("-r")
+	PORT_MANAGER_FLAGS+=("-r")
 fi
-
-DUMMY_VERSION="v3.3.1-0-g"
-GIT_DESC="$(cd "./phoenix-rtos-build" && git describe --tags --abbrev=0 --match "v[[:digit:]].[[:digit:]]*.[[:digit:]]*" 2> /dev/null || echo "${DUMMY_VERSION}")"
 
 b_log "Installing ports"
 
-PHOENIX_VER="${GIT_DESC}" port_manager build "${PORTS_CONFIG}" "${PREFIX_PROJECT}/phoenix-rtos-ports"
+PHOENIX_VER="v3.4.0" port_manager build "${PORTS_CONFIG}" "${PREFIX_PROJECT}/phoenix-rtos-ports"


### PR DESCRIPTION
On development branches PHOENIX_VER should refer to next tracking version, to allow for creation of new ports that are unsupported on previous releases.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [X] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [X] I will merge this PR by myself when appropriate.
