### PR TITLE
target/sparcv8leon: move kernel bss and data sections

### DIFF
--- a/target/sparcv8leon.mk
+++ b/target/sparcv8leon.mk
@@ -26,7 +26,8 @@ ifeq ($(TARGET_SUBFAMILY), gr716)
   CFLAGS += -msoft-float
 
   ifeq ($(KERNEL), 1)
-    LDFLAGS += -Wl,-z,max-page-size=0x200 -Tbss=40001a00 -Tdata=40001a00 -Wl,--section-start=.rodata=40000000
+    # On GR716 RAM is split into IRAM and DRAM, kernel data must be put into DRAM
+    LDFLAGS += -Wl,-z,max-page-size=0x200 -Tbss=40001c00 -Tdata=40001c00 -Wl,--section-start=.rodata=40000000
     STRIP := $(CROSS)strip
     CPPFLAGS += -DLEON_USE_PWR
   else


### PR DESCRIPTION
Growing .rodata section caused kernel sections overlap.

YT: RTOS-1344

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
